### PR TITLE
Voeg baseUrl toe aan config. Wanneer de E2E testen in een container gedraaid worden, dan is localhost niet beschikbaar en moet de naam van de container gebruikt worden. In dit geval 'tests'

### DIFF
--- a/test/e2e/config.js
+++ b/test/e2e/config.js
@@ -27,5 +27,6 @@ function gridEnabled() {
 module.exports = {
     "browserName": browserName(),
     "gridEnabled": gridEnabled(),
-    "gridUrl": "http://selenium-hub:4444/wd/hub"
+    "gridUrl": "http://selenium-hub:4444/wd/hub",
+    "baseUrl": gridEnabled() ? 'http://tests:8080' : 'http://localhost:8080'
 }


### PR DESCRIPTION
 Voeg baseUrl toe aan config. Wanneer de E2E testen in een container gedraaid worden, dan is localhost niet beschikbaar en moet de naam van de container gebruikt worden. In dit geval 'tests'

