### PR TITLE
Toevoegen van cookie extractie

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,5 +2,6 @@ module.exports = {
     'VlElement': require('./test/e2e/components/vl-element'), 
     'Page': require('./test/e2e/pages/page'), 
     'Config': require('./test/e2e/config'), 
-    'Test': require('./test/e2e/test')
+    'Test': require('./test/e2e/test'),
+    'Cookie': require('./test/e2e/components/cookie')
 }

--- a/test/e2e/components/cookie.js
+++ b/test/e2e/components/cookie.js
@@ -9,22 +9,6 @@ class Cookies {
             return cookie.name === name;
         }));
     }
-
-    async getCookieConsentCookie() {
-        return await this.get('vl-cookie-consent-cookie-consent');
-    }
-
-    async getCookieConsentDateCookie() {
-        return await this.get('vl-cookie-consent-cookie-consent-date');
-    }
-
-    async getCookieConsentOptedInFunctionalCookie() {
-        return await this.get('vl-cookie-consent-functional');
-    }
-
-    async getCookieConsentOptedInSocialCookie() {
-        return await this.get('vl-cookie-consent-socialmedia');
-    }
 }
 
 class Cookie {

--- a/test/e2e/components/cookie.js
+++ b/test/e2e/components/cookie.js
@@ -1,0 +1,47 @@
+class Cookies {
+    constructor(driver) {
+        this._driver = driver;
+    }
+
+    async get(name) {
+        const cookies = await this._driver.manage().getCookies();
+        return new Cookie(cookies.find(cookie => {
+            return cookie.name === name;
+        }));
+    }
+
+    async getCookieConsentCookie() {
+        return await this.get('vl-cookie-consent-cookie-consent');
+    }
+
+    async getCookieConsentDateCookie() {
+        return await this.get('vl-cookie-consent-cookie-consent-date');
+    }
+
+    async getCookieConsentOptedInFunctionalCookie() {
+        return await this.get('vl-cookie-consent-functional');
+    }
+
+    async getCookieConsentOptedInSocialCookie() {
+        return await this.get('vl-cookie-consent-socialmedia');
+    }
+}
+
+class Cookie {
+    constructor(cookie) {
+        if (cookie) {
+            this._value = cookie.value;
+            delete cookie.value;
+            Object.assign(this, cookie);
+        }
+    }
+
+    get value() {
+        return this._value ? JSON.parse(this._value) : undefined;
+    }
+}
+
+module.exports = {
+    Cookie: Cookie,
+    Cookies: Cookies
+};


### PR DESCRIPTION
cfr. https://github.com/milieuinfo/webcomponent-vl-ui-cookie-consent/pull/2/files/f8ba0bd8a7afe24ef3a30af1ae161ebd1947ed88#r356992903

In kader van VOORTOETS-3005 hebben we nood aan het uitlezen van cookies, en dit op een uniforme en gestructureerde manier. Logischerwijs steken we deze logica dan in de core.