### PR TITLE
Ondersteuning voor verouderde attribuut changed callback functies met prefix

### DIFF
--- a/src/vl-core.js
+++ b/src/vl-core.js
@@ -95,7 +95,11 @@ export const VlElement = (SuperClass) => {
                 this.__changeAttribute(this._element, oldValue, newValue, attribute);
             });
 
-            const callback = this['_' + attr.split('-').join('_') + 'ChangedCallback'] || this['_' + `${VlElement.attributePrefix}${attr}`.split('-').join('_') + 'ChangedCallback'];
+            const getCallbackFunctionName = (attribute) => {
+                return this['_' + attribute.split('-').join('_') + 'ChangedCallback']
+            }
+
+            const callback = this[getCallbackFunctionName(attr)] || this[getCallbackFunctionName(`${VlElement.attributePrefix}${attr}`)];
             if (callback) {
                 callback.call(this, oldValue, newValue);
             }

--- a/src/vl-core.js
+++ b/src/vl-core.js
@@ -95,7 +95,7 @@ export const VlElement = (SuperClass) => {
                 this.__changeAttribute(this._element, oldValue, newValue, attribute);
             });
 
-            const callback = this['_' + attr.split('-').join('_') + 'ChangedCallback'];
+            const callback = this['_' + attr.split('-').join('_') + 'ChangedCallback'] || this['_' + `${VlElement.attributePrefix}${attr}`.split('-').join('_') + 'ChangedCallback'];
             if (callback) {
                 callback.call(this, oldValue, newValue);
             }

--- a/test/unit/vl-core.test.html
+++ b/test/unit/vl-core.test.html
@@ -18,9 +18,21 @@
     </template>
   </test-fixture>
 
+  <test-fixture id="vl-native-prefixed-element-fixture">
+    <template>
+      <span is="vl-native-prefixed-element"></span>
+    </template>
+  </test-fixture>
+
   <test-fixture id="vl-element-fixture">
     <template>
       <vl-element></vl-element>
+    </template>
+  </test-fixture>
+
+  <test-fixture id="vl-prefixed-element-fixture">
+    <template>
+      <vl-prefixed-element></vl-prefixed-element>
     </template>
   </test-fixture>
 
@@ -41,6 +53,17 @@
           assert(element._attributeChangedCallback.calledWith(null, 'foo'));
           element.setAttribute(attribute, 'bar');
           assert(element._attributeChangedCallback.calledWith('foo', 'bar'));
+        });
+      });
+
+      test('wanneer er een attribuut met of zonder prefix uit de observed attributes lijst wijzigt, zal bij het ontbreken van een changed callback de prefixed changed callback functie aangeroepen worden', () => {
+        ['attribute', 'data-vl-attribute'].forEach((attribute) => {
+          const element = fixture('vl-native-prefixed-element-fixture');
+          sandbox.spy(element, '_data_vl_attributeChangedCallback');
+          element.setAttribute(attribute, 'foo');
+          assert(element._data_vl_attributeChangedCallback.calledWith(null, 'foo'));
+          element.setAttribute(attribute, 'bar');
+          assert(element._data_vl_attributeChangedCallback.calledWith('foo', 'bar'));
         });
       });
 
@@ -72,6 +95,17 @@
           assert(element._attributeChangedCallback.calledWith(null, 'foo'));
           element.setAttribute(attribute, 'bar');
           assert(element._attributeChangedCallback.calledWith('foo', 'bar'));
+        });
+      });
+
+      test('wanneer er een attribuut met of zonder prefix uit de observed attributes lijst wijzigt, zal bij het ontbreken van een changed callback de prefixed changed callback functie aangeroepen worden', () => {
+        ['attribute', 'data-vl-attribute'].forEach((attribute) => {
+          const element = fixture('vl-prefixed-element-fixture');
+          sandbox.spy(element, '_data_vl_attributeChangedCallback');
+          element.setAttribute(attribute, 'foo');
+          assert(element._data_vl_attributeChangedCallback.calledWith(null, 'foo'));
+          element.setAttribute(attribute, 'bar');
+          assert(element._data_vl_attributeChangedCallback.calledWith('foo', 'bar'));
         });
       });
 

--- a/test/unit/vl-core.test.html
+++ b/test/unit/vl-core.test.html
@@ -37,45 +37,58 @@
   </test-fixture>
 
   <script>
+    const sandbox = sinon.sandbox.create();
+
+    const assertAttributeChangedCallbackCall = (fixture) => {
+      const element = fixture;
+      sandbox.spy(element, '_attributeChangedCallback');
+      ['attribute', 'data-vl-attribute'].forEach((attribute) => {
+        element.setAttribute(attribute, 'foo');
+        assert(element._attributeChangedCallback.calledWith(null, 'foo'));
+        element.setAttribute(attribute, 'bar');
+        assert(element._attributeChangedCallback.calledWith('foo', 'bar'));
+      });
+    }
+
+    const assertPrefixedAttributeChangedCallbackCall = (fixture) => {
+      const element = fixture;
+      sandbox.spy(element, '_data_vl_attributeChangedCallback');
+      ['attribute', 'data-vl-attribute'].forEach((attribute) => {
+        element.setAttribute(attribute, 'foo');
+        assert(element._data_vl_attributeChangedCallback.calledWith(null, 'foo'));
+        element.setAttribute(attribute, 'bar');
+        assert(element._data_vl_attributeChangedCallback.calledWith('foo', 'bar'));
+      });
+    }
+
+    const assertAddedClass = (fixture) => {
+      const element = fixture;
+      assert.notInclude([...element.classList], 'vl-span--class-attribute');
+      ['class-attribute', 'data-vl-class-attribute'].forEach((attribute) => {
+        element.setAttribute(attribute, 'foo');
+        assert.include([...element.classList], 'vl-span--class-attribute');
+        element.removeAttribute(attribute);
+        assert.notInclude([...element.classList], 'vl-span--class-attribute');
+      });
+    }
+
     suite('vl-native-element', () => {
       const should = chai.should();
-      const sandbox = sinon.sandbox.create();
 
       teardown(() => {
         sandbox.restore();
       });
 
       test('wanneer er een attribuut met of zonder prefix uit de observed attributes lijst wijzigt, zal een changed callback functie aangeroepen worden', () => {
-        ['attribute', 'data-vl-attribute'].forEach((attribute) => {
-          const element = fixture('vl-native-element-fixture');
-          sandbox.spy(element, '_attributeChangedCallback');
-          element.setAttribute(attribute, 'foo');
-          assert(element._attributeChangedCallback.calledWith(null, 'foo'));
-          element.setAttribute(attribute, 'bar');
-          assert(element._attributeChangedCallback.calledWith('foo', 'bar'));
-        });
+        assertAttributeChangedCallbackCall(fixture('vl-native-element-fixture'));
       });
 
       test('wanneer er een attribuut met of zonder prefix uit de observed attributes lijst wijzigt, zal bij het ontbreken van een changed callback de prefixed changed callback functie aangeroepen worden', () => {
-        ['attribute', 'data-vl-attribute'].forEach((attribute) => {
-          const element = fixture('vl-native-prefixed-element-fixture');
-          sandbox.spy(element, '_data_vl_attributeChangedCallback');
-          element.setAttribute(attribute, 'foo');
-          assert(element._data_vl_attributeChangedCallback.calledWith(null, 'foo'));
-          element.setAttribute(attribute, 'bar');
-          assert(element._data_vl_attributeChangedCallback.calledWith('foo', 'bar'));
-        });
+        assertPrefixedAttributeChangedCallbackCall(fixture('vl-native-prefixed-element-fixture'));
       });
 
       test('wanneer er een attribuut met of zonder prefix uit de observed class attributes lijst wijzigt, zal een class (gebaseerd op class prefix en de attribuut naam) toegevoegd worden aan het root element', () => {
-        ['class-attribute', 'data-vl-class-attribute'].forEach((attribute) => {
-          const element = fixture('vl-native-element-fixture');
-          assert.notInclude([...element.classList], 'vl-span--class-attribute');
-          element.setAttribute(attribute, 'foo');
-          assert.include([...element.classList], 'vl-span--class-attribute');
-          element.removeAttribute(attribute);
-          assert.notInclude([...element.classList], 'vl-span--class-attribute');
-        });
+        assertAddedClass(fixture('vl-native-element-fixture'));
       });
     });
 
@@ -88,36 +101,15 @@
       });
 
       test('wanneer er een attribuut met of zonder prefix uit de observed attributes lijst wijzigt, zal een changed callback functie aangeroepen worden', () => {
-        ['attribute', 'data-vl-attribute'].forEach((attribute) => {
-          const element = fixture('vl-element-fixture');
-          sandbox.spy(element, '_attributeChangedCallback');
-          element.setAttribute(attribute, 'foo');
-          assert(element._attributeChangedCallback.calledWith(null, 'foo'));
-          element.setAttribute(attribute, 'bar');
-          assert(element._attributeChangedCallback.calledWith('foo', 'bar'));
-        });
+        assertAttributeChangedCallbackCall(fixture('vl-native-element-fixture'));
       });
 
       test('wanneer er een attribuut met of zonder prefix uit de observed attributes lijst wijzigt, zal bij het ontbreken van een changed callback de prefixed changed callback functie aangeroepen worden', () => {
-        ['attribute', 'data-vl-attribute'].forEach((attribute) => {
-          const element = fixture('vl-prefixed-element-fixture');
-          sandbox.spy(element, '_data_vl_attributeChangedCallback');
-          element.setAttribute(attribute, 'foo');
-          assert(element._data_vl_attributeChangedCallback.calledWith(null, 'foo'));
-          element.setAttribute(attribute, 'bar');
-          assert(element._data_vl_attributeChangedCallback.calledWith('foo', 'bar'));
-        });
+        assertPrefixedAttributeChangedCallbackCall(fixture('vl-prefixed-element-fixture'));
       });
 
       test('wanneer er een attribuut met of zonder prefix uit de observed class attributes lijst wijzigt, zal een class (gebaseerd op class prefix en de attribuut naam) toegevoegd worden aan het root element', () => {
-        ['class-attribute', 'data-vl-class-attribute'].forEach((attribute) => {
-          const element = fixture('vl-element-fixture');
-          assert.notInclude([...element.classList], 'vl-span--class-attribute');
-          element.setAttribute(attribute, 'foo');
-          assert.include([...element.classList], 'vl-span--class-attribute');
-          element.removeAttribute(attribute);
-          assert.notInclude([...element.classList], 'vl-span--class-attribute');
-        });
+        assertAddedClass(fixture('vl-element-fixture'));
       });
 
       test('wanneer er een attribuut met of zonder prefix uit de observed child class attributes lijst wijzigt, zal een class (gebaseerd op class prefix en de attribuut naam) toegevoegd worden aan het eerste shadow DOM element', () => {

--- a/test/unit/vl-element.js
+++ b/test/unit/vl-element.js
@@ -26,4 +26,31 @@ class VlElementImpl extends VlElement(HTMLElement) {
     _attributeChangedCallback(oldValue, newValue) { }
 }
 
+class VlPrefixedElementImpl extends VlElement(HTMLElement) {
+    static get _observedAttributes() {
+        return ['attribute'];
+    }
+
+    static get _observedClassAttributes() {
+        return ['class-attribute'];
+    }
+
+    static get _observedChildClassAttributes() {
+        return ['child-class-attribute'];
+    }
+
+    constructor() {
+        super(`
+            <div></div>
+        `);
+    }
+
+    get _classPrefix() {
+        return 'vl-span--';
+    }
+
+    _data_vl_attributeChangedCallback(oldValue, newValue) { }
+}
+
 define('vl-element', VlElementImpl);
+define('vl-prefixed-element', VlPrefixedElementImpl);

--- a/test/unit/vl-native-element.js
+++ b/test/unit/vl-native-element.js
@@ -16,4 +16,21 @@ class VlNativeElement extends NativeVlElement(HTMLSpanElement) {
     _attributeChangedCallback(oldValue, newValue) { }
 }
 
+class VlNativePrefixedElement extends NativeVlElement(HTMLSpanElement) {
+    static get _observedAttributes() {
+        return ['attribute'];
+    }
+
+    static get _observedClassAttributes() {
+        return ['class-attribute'];
+    }
+
+    get _classPrefix() {
+        return 'vl-span--';
+    }
+
+    _data_vl_attributeChangedCallback(oldValue, newValue) { }
+}
+
 define('vl-native-element', VlNativeElement, { extends: 'span' });
+define('vl-native-prefixed-element', VlNativePrefixedElement, { extends: 'span' });


### PR DESCRIPTION
Naar aanleiding van #61 is er ondersteuning toegevoegd voor HTML attributen met en zonder `data-vl` prefix. Er werd echter alleen maar de `attributeChangedCallback` zonder prefix aangeroepen. De bedoeling is dat op termijn de src code opgeruimd wordt en er geen prefix code meer nodig is, maar in de tussentijd willen we natuurlijk de `_data_vl_attributeChangedCallbacks` ook nog ondersteunen.