### PR TITLE
Duplicatie scripts wegwerken

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@babel/code-frame": {
       "version": "7.10.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/code-frame/-/code-frame-7.10.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/code-frame/-/code-frame-7.10.1.tgz",
       "integrity": "sha1-1UgcUJXaocV+FuVMb5GYRDr7Sf8=",
       "dev": true,
       "requires": {
@@ -15,7 +15,7 @@
     },
     "@babel/core": {
       "version": "7.10.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/core/-/core-7.10.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/core/-/core-7.10.2.tgz",
       "integrity": "sha1-vWeGBGZoqSWsK9L9lbV5uSojs2o=",
       "dev": true,
       "requires": {
@@ -39,7 +39,7 @@
       "dependencies": {
         "debug": {
           "version": "4.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-4.1.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/debug/-/debug-4.1.1.tgz",
           "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
           "dev": true,
           "requires": {
@@ -48,19 +48,19 @@
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.1.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ms/-/ms-2.1.2.tgz",
           "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
           "dev": true
         },
         "semver": {
           "version": "5.7.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/semver/-/semver-5.7.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/semver/-/semver-5.7.1.tgz",
           "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc=",
           "dev": true
         },
         "source-map": {
           "version": "0.5.7",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "dev": true
         }
@@ -68,7 +68,7 @@
     },
     "@babel/generator": {
       "version": "7.10.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/generator/-/generator-7.10.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/generator/-/generator-7.10.2.tgz",
       "integrity": "sha1-D6W1sjiduL/fzDSStVHuIPXdaak=",
       "dev": true,
       "requires": {
@@ -80,7 +80,7 @@
       "dependencies": {
         "source-map": {
           "version": "0.5.7",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "dev": true
         }
@@ -88,7 +88,7 @@
     },
     "@babel/helper-annotate-as-pure": {
       "version": "7.10.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.10.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.10.1.tgz",
       "integrity": "sha1-9tCKzG9wu9WbQ2JiVT+y4lmhomg=",
       "dev": true,
       "requires": {
@@ -97,7 +97,7 @@
     },
     "@babel/helper-builder-binary-assignment-operator-visitor": {
       "version": "7.10.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.10.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.10.1.tgz",
       "integrity": "sha1-DsfZvoF0k0UyZh+HeD6xjXIpAFk=",
       "dev": true,
       "requires": {
@@ -107,7 +107,7 @@
     },
     "@babel/helper-create-regexp-features-plugin": {
       "version": "7.10.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.10.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.10.1.tgz",
       "integrity": "sha1-G4/uqxWUy8+/OrWju8q6wEaO/b0=",
       "dev": true,
       "requires": {
@@ -118,7 +118,7 @@
     },
     "@babel/helper-define-map": {
       "version": "7.10.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/helper-define-map/-/helper-define-map-7.10.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/helper-define-map/-/helper-define-map-7.10.1.tgz",
       "integrity": "sha1-XmnugwhkhHDdeQDRWcBEwQKFIh0=",
       "dev": true,
       "requires": {
@@ -129,7 +129,7 @@
     },
     "@babel/helper-explode-assignable-expression": {
       "version": "7.10.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.10.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.10.1.tgz",
       "integrity": "sha1-6ddjBe4RYspGc1euJd+U8XmvK34=",
       "dev": true,
       "requires": {
@@ -139,7 +139,7 @@
     },
     "@babel/helper-function-name": {
       "version": "7.10.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/helper-function-name/-/helper-function-name-7.10.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/helper-function-name/-/helper-function-name-7.10.1.tgz",
       "integrity": "sha1-kr1jgpv8khWsqdne+oX1a1OUVPQ=",
       "dev": true,
       "requires": {
@@ -150,7 +150,7 @@
     },
     "@babel/helper-get-function-arity": {
       "version": "7.10.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.1.tgz",
       "integrity": "sha1-cwM5CoG6fLWWE4laGSuThQ43P30=",
       "dev": true,
       "requires": {
@@ -159,7 +159,7 @@
     },
     "@babel/helper-member-expression-to-functions": {
       "version": "7.10.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.10.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.10.1.tgz",
       "integrity": "sha1-Qyln/X4SpK/vZsRofUyiK8BFbxU=",
       "dev": true,
       "requires": {
@@ -168,7 +168,7 @@
     },
     "@babel/helper-module-imports": {
       "version": "7.10.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/helper-module-imports/-/helper-module-imports-7.10.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/helper-module-imports/-/helper-module-imports-7.10.1.tgz",
       "integrity": "sha1-3TMb1FvMxWbOdwBOnQX+F63ROHY=",
       "dev": true,
       "requires": {
@@ -177,7 +177,7 @@
     },
     "@babel/helper-module-transforms": {
       "version": "7.10.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/helper-module-transforms/-/helper-module-transforms-7.10.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/helper-module-transforms/-/helper-module-transforms-7.10.1.tgz",
       "integrity": "sha1-JOLwjuaDLGCxV7sJNshr73IQxiI=",
       "dev": true,
       "requires": {
@@ -192,7 +192,7 @@
     },
     "@babel/helper-optimise-call-expression": {
       "version": "7.10.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.1.tgz",
       "integrity": "sha1-tKHyVhhwzhJHzt2wKjhg+pbXJUM=",
       "dev": true,
       "requires": {
@@ -201,13 +201,13 @@
     },
     "@babel/helper-plugin-utils": {
       "version": "7.10.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.1.tgz",
       "integrity": "sha1-7Fpc8O7JJbZsYFgDKLEiwBIwoSc=",
       "dev": true
     },
     "@babel/helper-regex": {
       "version": "7.10.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/helper-regex/-/helper-regex-7.10.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/helper-regex/-/helper-regex-7.10.1.tgz",
       "integrity": "sha1-Ahzxp7qZgi+ZMiKgAcw/7IMlW5Y=",
       "dev": true,
       "requires": {
@@ -216,7 +216,7 @@
     },
     "@babel/helper-remap-async-to-generator": {
       "version": "7.10.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.10.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.10.1.tgz",
       "integrity": "sha1-utaqpP85zo1Lgsyq4L/g99u19DI=",
       "dev": true,
       "requires": {
@@ -229,7 +229,7 @@
     },
     "@babel/helper-replace-supers": {
       "version": "7.10.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/helper-replace-supers/-/helper-replace-supers-7.10.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/helper-replace-supers/-/helper-replace-supers-7.10.1.tgz",
       "integrity": "sha1-7GhZ0gxdgIf2otxOAU23Iol18T0=",
       "dev": true,
       "requires": {
@@ -241,7 +241,7 @@
     },
     "@babel/helper-simple-access": {
       "version": "7.10.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/helper-simple-access/-/helper-simple-access-7.10.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/helper-simple-access/-/helper-simple-access-7.10.1.tgz",
       "integrity": "sha1-CPt+Iqzp64Mm9+OSChwgUvE9hR4=",
       "dev": true,
       "requires": {
@@ -251,7 +251,7 @@
     },
     "@babel/helper-split-export-declaration": {
       "version": "7.10.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.10.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.10.1.tgz",
       "integrity": "sha1-xvS+HLwV46ho5MZKF9XTHXVNo18=",
       "dev": true,
       "requires": {
@@ -260,13 +260,13 @@
     },
     "@babel/helper-validator-identifier": {
       "version": "7.10.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.1.tgz",
       "integrity": "sha1-V3CwwagmxPU/Xt5eFTFj4DGOlLU=",
       "dev": true
     },
     "@babel/helper-wrap-function": {
       "version": "7.10.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/helper-wrap-function/-/helper-wrap-function-7.10.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/helper-wrap-function/-/helper-wrap-function-7.10.1.tgz",
       "integrity": "sha1-lW0TENZpYlenr9R+TELf2l387ck=",
       "dev": true,
       "requires": {
@@ -278,7 +278,7 @@
     },
     "@babel/helpers": {
       "version": "7.10.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/helpers/-/helpers-7.10.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/helpers/-/helpers-7.10.1.tgz",
       "integrity": "sha1-poJ7fLl1ydnO9f1h2Rn2DYhEqXM=",
       "dev": true,
       "requires": {
@@ -289,7 +289,7 @@
     },
     "@babel/highlight": {
       "version": "7.10.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/highlight/-/highlight-7.10.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/highlight/-/highlight-7.10.1.tgz",
       "integrity": "sha1-hB0Ji6YTuhpCeis4PXnjVVLDiuA=",
       "dev": true,
       "requires": {
@@ -300,7 +300,7 @@
       "dependencies": {
         "chalk": {
           "version": "2.4.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/chalk/-/chalk-2.4.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
           "dev": true,
           "requires": {
@@ -313,13 +313,13 @@
     },
     "@babel/parser": {
       "version": "7.10.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/parser/-/parser-7.10.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/parser/-/parser-7.10.2.tgz",
       "integrity": "sha1-hxgH8QRCuS/5fkeDubVPagyoEtA=",
       "dev": true
     },
     "@babel/plugin-external-helpers": {
       "version": "7.10.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-external-helpers/-/plugin-external-helpers-7.10.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/plugin-external-helpers/-/plugin-external-helpers-7.10.1.tgz",
       "integrity": "sha1-m6aagBGhY8PHPc4WLfHmc3xOjc8=",
       "dev": true,
       "requires": {
@@ -328,7 +328,7 @@
     },
     "@babel/plugin-proposal-async-generator-functions": {
       "version": "7.10.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.10.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.10.1.tgz",
       "integrity": "sha1-aRGvW6LmFcT/PEl/4vR7Nb9tflU=",
       "dev": true,
       "requires": {
@@ -339,7 +339,7 @@
     },
     "@babel/plugin-proposal-object-rest-spread": {
       "version": "7.10.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.10.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.10.1.tgz",
       "integrity": "sha1-y6RJCKyfFCZQtKZbiqBr80eNX7Y=",
       "dev": true,
       "requires": {
@@ -350,7 +350,7 @@
     },
     "@babel/plugin-syntax-async-generators": {
       "version": "7.8.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
       "integrity": "sha1-qYP7Gusuw/btBCohD2QOkOeG/g0=",
       "dev": true,
       "requires": {
@@ -359,7 +359,7 @@
     },
     "@babel/plugin-syntax-dynamic-import": {
       "version": "7.8.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.8.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.8.3.tgz",
       "integrity": "sha1-Yr+Ysto80h1iYVT8lu5bPLaOrLM=",
       "dev": true,
       "requires": {
@@ -368,7 +368,7 @@
     },
     "@babel/plugin-syntax-import-meta": {
       "version": "7.10.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.1.tgz",
       "integrity": "sha1-PlkSDtizwszFq7HPx6qj6gHNNrY=",
       "dev": true,
       "requires": {
@@ -377,7 +377,7 @@
     },
     "@babel/plugin-syntax-object-rest-spread": {
       "version": "7.8.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
       "integrity": "sha1-YOIl7cvZimQDMqLnLdPmbxr1WHE=",
       "dev": true,
       "requires": {
@@ -386,7 +386,7 @@
     },
     "@babel/plugin-transform-arrow-functions": {
       "version": "7.10.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.10.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.10.1.tgz",
       "integrity": "sha1-y17jo28IY8BurQtAm0zEOoibKVs=",
       "dev": true,
       "requires": {
@@ -395,7 +395,7 @@
     },
     "@babel/plugin-transform-async-to-generator": {
       "version": "7.10.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.10.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.10.1.tgz",
       "integrity": "sha1-5RU+saPgKPeRlO2Kekv1X4YrIGI=",
       "dev": true,
       "requires": {
@@ -406,7 +406,7 @@
     },
     "@babel/plugin-transform-block-scoped-functions": {
       "version": "7.10.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.10.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.10.1.tgz",
       "integrity": "sha1-FGhW51bVSyD/8UuBlFaz4BgguF0=",
       "dev": true,
       "requires": {
@@ -415,7 +415,7 @@
     },
     "@babel/plugin-transform-block-scoping": {
       "version": "7.10.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.10.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.10.1.tgz",
       "integrity": "sha1-Rwktico0WBFFHNDcXZFgWYJwXV4=",
       "dev": true,
       "requires": {
@@ -425,7 +425,7 @@
     },
     "@babel/plugin-transform-classes": {
       "version": "7.10.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-transform-classes/-/plugin-transform-classes-7.10.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/plugin-transform-classes/-/plugin-transform-classes-7.10.1.tgz",
       "integrity": "sha1-bhHdbE365w9UBICkcCR37XZtcz8=",
       "dev": true,
       "requires": {
@@ -441,7 +441,7 @@
       "dependencies": {
         "globals": {
           "version": "11.12.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/globals/-/globals-11.12.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/globals/-/globals-11.12.0.tgz",
           "integrity": "sha1-q4eVM4hooLq9hSV1gBjCp+uVxC4=",
           "dev": true
         }
@@ -449,7 +449,7 @@
     },
     "@babel/plugin-transform-computed-properties": {
       "version": "7.10.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.10.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.10.1.tgz",
       "integrity": "sha1-Wao5kGRCnWTc5c9275uQtyRevQc=",
       "dev": true,
       "requires": {
@@ -458,7 +458,7 @@
     },
     "@babel/plugin-transform-destructuring": {
       "version": "7.10.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.10.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.10.1.tgz",
       "integrity": "sha1-q9WOUTN4Fco6IqM2uF9iuZjnGQc=",
       "dev": true,
       "requires": {
@@ -467,7 +467,7 @@
     },
     "@babel/plugin-transform-duplicate-keys": {
       "version": "7.10.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.10.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.10.1.tgz",
       "integrity": "sha1-yQCnk76wlrydTQqdDN4ZUY/8g7k=",
       "dev": true,
       "requires": {
@@ -476,7 +476,7 @@
     },
     "@babel/plugin-transform-exponentiation-operator": {
       "version": "7.10.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.10.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.10.1.tgz",
       "integrity": "sha1-J5wxFnVqYN1ub15Ii6eVfbnFnrM=",
       "dev": true,
       "requires": {
@@ -486,7 +486,7 @@
     },
     "@babel/plugin-transform-for-of": {
       "version": "7.10.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.10.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.10.1.tgz",
       "integrity": "sha1-/wERl4TrDuMiWOhkYVe6JQH8/aU=",
       "dev": true,
       "requires": {
@@ -495,7 +495,7 @@
     },
     "@babel/plugin-transform-function-name": {
       "version": "7.10.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.10.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.10.1.tgz",
       "integrity": "sha1-TtRv1uHY/eKi7HsDxm2FPSySQn0=",
       "dev": true,
       "requires": {
@@ -505,7 +505,7 @@
     },
     "@babel/plugin-transform-instanceof": {
       "version": "7.10.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-transform-instanceof/-/plugin-transform-instanceof-7.10.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/plugin-transform-instanceof/-/plugin-transform-instanceof-7.10.1.tgz",
       "integrity": "sha1-2sUsQe+B14p1W4OFq3vUh4pJhCo=",
       "dev": true,
       "requires": {
@@ -514,7 +514,7 @@
     },
     "@babel/plugin-transform-literals": {
       "version": "7.10.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-transform-literals/-/plugin-transform-literals-7.10.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/plugin-transform-literals/-/plugin-transform-literals-7.10.1.tgz",
       "integrity": "sha1-V5T42oKEayLk5mMeoWWLznCOtGo=",
       "dev": true,
       "requires": {
@@ -523,7 +523,7 @@
     },
     "@babel/plugin-transform-modules-amd": {
       "version": "7.10.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.10.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.10.1.tgz",
       "integrity": "sha1-ZZUOjgV5fr0v5TK5bhn8VIKh1So=",
       "dev": true,
       "requires": {
@@ -534,7 +534,7 @@
     },
     "@babel/plugin-transform-object-super": {
       "version": "7.10.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.10.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.10.1.tgz",
       "integrity": "sha1-LjAWsK2/JimDvw1RIdZ2pe2cT94=",
       "dev": true,
       "requires": {
@@ -544,7 +544,7 @@
     },
     "@babel/plugin-transform-parameters": {
       "version": "7.10.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.10.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.10.1.tgz",
       "integrity": "sha1-slk4o8X64DVBRKcgsHsydm9oPd0=",
       "dev": true,
       "requires": {
@@ -554,7 +554,7 @@
     },
     "@babel/plugin-transform-regenerator": {
       "version": "7.10.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.10.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.10.1.tgz",
       "integrity": "sha1-EOF1y+e9tjzJs5+bP4I8XHxcVJA=",
       "dev": true,
       "requires": {
@@ -563,7 +563,7 @@
     },
     "@babel/plugin-transform-shorthand-properties": {
       "version": "7.10.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.10.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.10.1.tgz",
       "integrity": "sha1-6LVPI4ocy65ILE3OlGGArnsxQ/M=",
       "dev": true,
       "requires": {
@@ -572,7 +572,7 @@
     },
     "@babel/plugin-transform-spread": {
       "version": "7.10.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-transform-spread/-/plugin-transform-spread-7.10.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/plugin-transform-spread/-/plugin-transform-spread-7.10.1.tgz",
       "integrity": "sha1-DG1higxEYaJ0QYRgooycz1I5p8g=",
       "dev": true,
       "requires": {
@@ -581,7 +581,7 @@
     },
     "@babel/plugin-transform-sticky-regex": {
       "version": "7.10.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.10.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.10.1.tgz",
       "integrity": "sha1-kPyJt1JiKL7ZhCz/NYgnCno5OwA=",
       "dev": true,
       "requires": {
@@ -591,7 +591,7 @@
     },
     "@babel/plugin-transform-template-literals": {
       "version": "7.10.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.10.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.10.1.tgz",
       "integrity": "sha1-kUx7f0dSxXDqAFU7QoTa2AcOhig=",
       "dev": true,
       "requires": {
@@ -601,7 +601,7 @@
     },
     "@babel/plugin-transform-typeof-symbol": {
       "version": "7.10.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.10.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.10.1.tgz",
       "integrity": "sha1-YMAjm2mWXRZrgKhN5zFcG8fguw4=",
       "dev": true,
       "requires": {
@@ -610,7 +610,7 @@
     },
     "@babel/plugin-transform-unicode-regex": {
       "version": "7.10.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.10.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.10.1.tgz",
       "integrity": "sha1-a1jyrqe2jfN6xQJdnIh1JEOmtD8=",
       "dev": true,
       "requires": {
@@ -620,7 +620,7 @@
     },
     "@babel/runtime": {
       "version": "7.10.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/runtime/-/runtime-7.10.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/runtime/-/runtime-7.10.2.tgz",
       "integrity": "sha1-0QPyHyYCSX04NIoy4AhjfVBtuDk=",
       "dev": true,
       "requires": {
@@ -629,7 +629,7 @@
       "dependencies": {
         "regenerator-runtime": {
           "version": "0.13.5",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
           "integrity": "sha1-2Hih0JS0MG0QuQlkhLM+vVXiZpc=",
           "dev": true
         }
@@ -637,7 +637,7 @@
     },
     "@babel/template": {
       "version": "7.10.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/template/-/template-7.10.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/template/-/template-7.10.1.tgz",
       "integrity": "sha1-4WcVSpTLXxSyjcWPU1bSFi9TmBE=",
       "dev": true,
       "requires": {
@@ -648,7 +648,7 @@
     },
     "@babel/traverse": {
       "version": "7.10.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/traverse/-/traverse-7.10.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/traverse/-/traverse-7.10.1.tgz",
       "integrity": "sha1-u87zAx5BUqbAtQFH9JWN9Uyg3Sc=",
       "dev": true,
       "requires": {
@@ -665,7 +665,7 @@
       "dependencies": {
         "debug": {
           "version": "4.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-4.1.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/debug/-/debug-4.1.1.tgz",
           "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
           "dev": true,
           "requires": {
@@ -674,13 +674,13 @@
         },
         "globals": {
           "version": "11.12.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/globals/-/globals-11.12.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/globals/-/globals-11.12.0.tgz",
           "integrity": "sha1-q4eVM4hooLq9hSV1gBjCp+uVxC4=",
           "dev": true
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.1.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ms/-/ms-2.1.2.tgz",
           "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
           "dev": true
         }
@@ -688,7 +688,7 @@
     },
     "@babel/types": {
       "version": "7.10.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@babel/types/-/types-7.10.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/types/-/types-7.10.2.tgz",
       "integrity": "sha1-MCg74xytDb9vsAvUBkHKDqZ1Fy0=",
       "dev": true,
       "requires": {
@@ -699,7 +699,7 @@
     },
     "@govflanders/vl-ui-core": {
       "version": "3.9.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@govflanders/vl-ui-core/vl-ui-core-3.9.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@govflanders/vl-ui-core/vl-ui-core-3.9.2.tgz",
       "integrity": "sha1-osqVHvgkAGui5su4qtAfwkz0MLw=",
       "dev": true,
       "requires": {
@@ -715,7 +715,7 @@
     },
     "@govflanders/vl-ui-util": {
       "version": "3.9.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@govflanders/vl-ui-util/vl-ui-util-3.9.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@govflanders/vl-ui-util/vl-ui-util-3.9.2.tgz",
       "integrity": "sha1-0u8U5uJ45MrIiIhuWKKJ52n/wio=",
       "dev": true,
       "requires": {
@@ -728,7 +728,7 @@
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
       "integrity": "sha1-Olgr21OATGum0UZXnEblITDPSjs=",
       "dev": true,
       "requires": {
@@ -738,13 +738,13 @@
     },
     "@nodelib/fs.stat": {
       "version": "2.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
       "integrity": "sha1-NNxfTKu8cg9OYPdadH5+zWwXW9M=",
       "dev": true
     },
     "@nodelib/fs.walk": {
       "version": "1.2.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz",
       "integrity": "sha1-ARuSAqcKY2bkNspcBlhEUoqwSXY=",
       "dev": true,
       "requires": {
@@ -754,13 +754,13 @@
     },
     "@polymer/esm-amd-loader": {
       "version": "1.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@polymer/esm-amd-loader/-/esm-amd-loader-1.0.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@polymer/esm-amd-loader/-/esm-amd-loader-1.0.4.tgz",
       "integrity": "sha1-Tnfy9ZspsB4K0CqoPTNxbN3F+fk=",
       "dev": true
     },
     "@polymer/polymer": {
       "version": "3.4.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@polymer/polymer/-/polymer-3.4.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@polymer/polymer/-/polymer-3.4.1.tgz",
       "integrity": "sha1-MzvvJXEfhBG7ViT7PrqCEu+L7pY=",
       "dev": true,
       "requires": {
@@ -769,19 +769,19 @@
     },
     "@polymer/sinonjs": {
       "version": "1.17.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@polymer/sinonjs/-/sinonjs-1.17.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@polymer/sinonjs/-/sinonjs-1.17.1.tgz",
       "integrity": "sha1-5H03hbfQ6MKf65f36SSw/Fl+Lps=",
       "dev": true
     },
     "@polymer/test-fixture": {
       "version": "3.0.0-pre.21",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@polymer/test-fixture/-/test-fixture-3.0.0-pre.21.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@polymer/test-fixture/-/test-fixture-3.0.0-pre.21.tgz",
       "integrity": "sha1-hRUiB8sL9XyuvBkcgLsP22lSYU4=",
       "dev": true
     },
     "@samverschueren/stream-to-observable": {
       "version": "0.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz",
       "integrity": "sha1-7N9I1TLFjqR3rPyrgDSEJPjQZi8=",
       "dev": true,
       "requires": {
@@ -790,7 +790,7 @@
       "dependencies": {
         "any-observable": {
           "version": "0.3.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/any-observable/-/any-observable-0.3.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/any-observable/-/any-observable-0.3.0.tgz",
           "integrity": "sha1-r5M0deWAamfQ198JDdXovvZdEZs=",
           "dev": true
         }
@@ -798,13 +798,13 @@
     },
     "@sindresorhus/is": {
       "version": "0.14.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@sindresorhus/is/-/is-0.14.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@sindresorhus/is/-/is-0.14.0.tgz",
       "integrity": "sha1-n7OjzzEyMoFR81PeRjLgHlIQK+o=",
       "dev": true
     },
     "@sinonjs/commons": {
       "version": "1.8.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@sinonjs/commons/-/commons-1.8.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@sinonjs/commons/-/commons-1.8.0.tgz",
       "integrity": "sha1-yNaIIahUxVW7oXLzsGlZoAObI20=",
       "dev": true,
       "requires": {
@@ -813,7 +813,7 @@
     },
     "@sinonjs/fake-timers": {
       "version": "6.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz",
       "integrity": "sha1-KTZ0/MsyYqx4LHqt/eyoaxDHXEA=",
       "dev": true,
       "requires": {
@@ -822,7 +822,7 @@
     },
     "@sinonjs/formatio": {
       "version": "5.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@sinonjs/formatio/-/formatio-5.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@sinonjs/formatio/-/formatio-5.0.1.tgz",
       "integrity": "sha1-8T5xPLMxOxq5ZZAbAbCCjqa3cIk=",
       "dev": true,
       "requires": {
@@ -832,7 +832,7 @@
     },
     "@sinonjs/samsam": {
       "version": "5.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@sinonjs/samsam/-/samsam-5.0.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@sinonjs/samsam/-/samsam-5.0.3.tgz",
       "integrity": "sha1-hvIb2z1SSA+vCJKkgMmQaqWlKTg=",
       "dev": true,
       "requires": {
@@ -843,13 +843,13 @@
     },
     "@sinonjs/text-encoding": {
       "version": "0.7.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
       "integrity": "sha1-jaXGUwkVZT86Hzj9XxAdjD+AecU=",
       "dev": true
     },
     "@szmarczak/http-timer": {
       "version": "1.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
       "integrity": "sha1-sWZeLEYaLNkvTBu/UNVFTeDUtCE=",
       "dev": true,
       "requires": {
@@ -858,13 +858,13 @@
     },
     "@testim/chrome-version": {
       "version": "1.0.7",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@testim/chrome-version/-/chrome-version-1.0.7.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@testim/chrome-version/-/chrome-version-1.0.7.tgz",
       "integrity": "sha1-DNkVeF7EGQ8Io6asybYfw4+18ak=",
       "dev": true
     },
     "@types/babel-generator": {
       "version": "6.25.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/babel-generator/-/babel-generator-6.25.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/babel-generator/-/babel-generator-6.25.3.tgz",
       "integrity": "sha1-jwbKoS0FlaBThWCr53GWbXfSkoY=",
       "dev": true,
       "requires": {
@@ -873,7 +873,7 @@
     },
     "@types/babel-traverse": {
       "version": "6.25.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/babel-traverse/-/babel-traverse-6.25.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/babel-traverse/-/babel-traverse-6.25.5.tgz",
       "integrity": "sha1-bSk891I+SLUk+qe4bcPEiBkUhOU=",
       "dev": true,
       "requires": {
@@ -882,13 +882,13 @@
     },
     "@types/babel-types": {
       "version": "6.25.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/babel-types/-/babel-types-6.25.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/babel-types/-/babel-types-6.25.2.tgz",
       "integrity": "sha1-XFf0WXPk8TdC28UnPdhM/+c3Op4=",
       "dev": true
     },
     "@types/babylon": {
       "version": "6.16.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/babylon/-/babylon-6.16.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/babylon/-/babylon-6.16.5.tgz",
       "integrity": "sha1-HFZB22nrjN83jt0ltL53VL7rSLQ=",
       "dev": true,
       "requires": {
@@ -897,13 +897,13 @@
     },
     "@types/bluebird": {
       "version": "3.5.32",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/bluebird/-/bluebird-3.5.32.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/bluebird/-/bluebird-3.5.32.tgz",
       "integrity": "sha1-OB57WeOfAQ0gu/fgROSPXK8atiA=",
       "dev": true
     },
     "@types/body-parser": {
       "version": "1.19.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/body-parser/-/body-parser-1.19.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/body-parser/-/body-parser-1.19.0.tgz",
       "integrity": "sha1-BoWzxH6zAG/+0RfN1VFkth+AU48=",
       "dev": true,
       "requires": {
@@ -913,13 +913,13 @@
     },
     "@types/chai": {
       "version": "4.2.11",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/chai/-/chai-4.2.11.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/chai/-/chai-4.2.11.tgz",
       "integrity": "sha1-02FNbF9QAUI1jm7SThvxZldTbFA=",
       "dev": true
     },
     "@types/chai-subset": {
       "version": "1.3.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/chai-subset/-/chai-subset-1.3.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/chai-subset/-/chai-subset-1.3.3.tgz",
       "integrity": "sha1-l4k4FOkqvSxTTeQiyzd+DgvarJQ=",
       "dev": true,
       "requires": {
@@ -928,13 +928,13 @@
     },
     "@types/chalk": {
       "version": "0.4.31",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/chalk/-/chalk-0.4.31.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/chalk/-/chalk-0.4.31.tgz",
       "integrity": "sha1-ox10JBprHtu5c8822XooloNKUfk=",
       "dev": true
     },
     "@types/clean-css": {
       "version": "4.2.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/clean-css/-/clean-css-4.2.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/clean-css/-/clean-css-4.2.1.tgz",
       "integrity": "sha1-ywE0JB7F5u3htTRLyClmj9mHGo0=",
       "dev": true,
       "requires": {
@@ -943,19 +943,19 @@
     },
     "@types/clone": {
       "version": "0.1.30",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/clone/-/clone-0.1.30.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/clone/-/clone-0.1.30.tgz",
       "integrity": "sha1-5zZWSMG0ITalnH1QQGN7O1yDthQ=",
       "dev": true
     },
     "@types/color-name": {
       "version": "1.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/color-name/-/color-name-1.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/color-name/-/color-name-1.1.1.tgz",
       "integrity": "sha1-HBJhu+qhCoBVu8XYq4S3sq/IRqA=",
       "dev": true
     },
     "@types/compression": {
       "version": "0.0.33",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/compression/-/compression-0.0.33.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/compression/-/compression-0.0.33.tgz",
       "integrity": "sha1-ldxzOiM5qoRjgdfxN3eS0lU9wn0=",
       "dev": true,
       "requires": {
@@ -964,7 +964,7 @@
     },
     "@types/connect": {
       "version": "3.4.33",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/connect/-/connect-3.4.33.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/connect/-/connect-3.4.33.tgz",
       "integrity": "sha1-MWEMkB7KVzuHE8MzCrxua59YhUY=",
       "dev": true,
       "requires": {
@@ -973,43 +973,43 @@
     },
     "@types/content-type": {
       "version": "1.1.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/content-type/-/content-type-1.1.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/content-type/-/content-type-1.1.3.tgz",
       "integrity": "sha1-Noi9d/wS+TVUju8QKk40xRKwOgc=",
       "dev": true
     },
     "@types/cssbeautify": {
       "version": "0.3.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/cssbeautify/-/cssbeautify-0.3.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/cssbeautify/-/cssbeautify-0.3.1.tgz",
       "integrity": "sha1-jgvuj33suVIlDaDK6+BeMFkcF+8=",
       "dev": true
     },
     "@types/doctrine": {
       "version": "0.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/doctrine/-/doctrine-0.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/doctrine/-/doctrine-0.0.1.tgz",
       "integrity": "sha1-uZny2fe0PKvgoaLzm8IDvH3K2p0=",
       "dev": true
     },
     "@types/escape-html": {
       "version": "0.0.20",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/escape-html/-/escape-html-0.0.20.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/escape-html/-/escape-html-0.0.20.tgz",
       "integrity": "sha1-yuaYcU3WHr7lqz8q65o0uhARc1o=",
       "dev": true
     },
     "@types/estree": {
       "version": "0.0.44",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/estree/-/estree-0.0.44.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/estree/-/estree-0.0.44.tgz",
       "integrity": "sha1-mAzFopo+876m/x99AhBH1+pXXiE=",
       "dev": true
     },
     "@types/expect": {
       "version": "1.20.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/expect/-/expect-1.20.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/expect/-/expect-1.20.4.tgz",
       "integrity": "sha1-gojlFze/fjq118d7+mlYg3RSZOU=",
       "dev": true
     },
     "@types/express": {
       "version": "4.17.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/express/-/express-4.17.6.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/express/-/express-4.17.6.tgz",
       "integrity": "sha1-a85J5JVwUHuG6hsHuAbwRpf6xF4=",
       "dev": true,
       "requires": {
@@ -1021,7 +1021,7 @@
     },
     "@types/express-serve-static-core": {
       "version": "4.17.7",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/express-serve-static-core/-/express-serve-static-core-4.17.7.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/express-serve-static-core/-/express-serve-static-core-4.17.7.tgz",
       "integrity": "sha1-3+Yfhw61SdxtfhIFCQGEfH1+kVs=",
       "dev": true,
       "requires": {
@@ -1032,7 +1032,7 @@
     },
     "@types/freeport": {
       "version": "1.0.21",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/freeport/-/freeport-1.0.21.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/freeport/-/freeport-1.0.21.tgz",
       "integrity": "sha1-c/ZUPtZ9PKP/+XuYVZFZi3CSBm8=",
       "dev": true,
       "optional": true
@@ -1049,7 +1049,7 @@
     },
     "@types/glob-stream": {
       "version": "6.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/glob-stream/-/glob-stream-6.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/glob-stream/-/glob-stream-6.1.0.tgz",
       "integrity": "sha1-ft6KM+WRQFNPjYrfuKye37MYl7w=",
       "dev": true,
       "requires": {
@@ -1059,7 +1059,7 @@
     },
     "@types/gulp-if": {
       "version": "0.0.33",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/gulp-if/-/gulp-if-0.0.33.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/gulp-if/-/gulp-if-0.0.33.tgz",
       "integrity": "sha1-7eziK3kl2abbX5yMDXiCqndvtng=",
       "dev": true,
       "requires": {
@@ -1069,7 +1069,7 @@
     },
     "@types/html-minifier": {
       "version": "3.5.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/html-minifier/-/html-minifier-3.5.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/html-minifier/-/html-minifier-3.5.3.tgz",
       "integrity": "sha1-UnaEUTjbLOvFTHieCq+HYhoh6E8=",
       "dev": true,
       "requires": {
@@ -1080,38 +1080,38 @@
     },
     "@types/is-windows": {
       "version": "0.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/is-windows/-/is-windows-0.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/is-windows/-/is-windows-0.2.0.tgz",
       "integrity": "sha1-byTuSHMdMRaOpRBhDW3RXl/Jxv8=",
       "dev": true
     },
     "@types/launchpad": {
       "version": "0.6.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/launchpad/-/launchpad-0.6.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/launchpad/-/launchpad-0.6.0.tgz",
       "integrity": "sha1-NylhCbfyd/bmxf1+DAcGvJGPu1E=",
       "dev": true,
       "optional": true
     },
     "@types/mime": {
       "version": "2.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/mime/-/mime-2.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/mime/-/mime-2.0.2.tgz",
       "integrity": "sha1-hXoRjYY0yEu6euFAiORQhJDNXaU=",
       "dev": true
     },
     "@types/minimatch": {
       "version": "3.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/minimatch/-/minimatch-3.0.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/minimatch/-/minimatch-3.0.3.tgz",
       "integrity": "sha1-PcoOPzOyAPx9ETnAzZbBJoyt/Z0=",
       "dev": true
     },
     "@types/minimist": {
       "version": "1.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/minimist/-/minimist-1.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-aaI6OtKcrwCX8G7aWbNh7i8GOfY=",
       "dev": true
     },
     "@types/mz": {
       "version": "0.0.29",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/mz/-/mz-0.0.29.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/mz/-/mz-0.0.29.tgz",
       "integrity": "sha1-vCRyjGSZc/HHhR6QM/nOUlZowns=",
       "dev": true,
       "requires": {
@@ -1127,13 +1127,13 @@
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
       "integrity": "sha1-5IbQ2XOW15vu3QpuM/RTT/a0lz4=",
       "dev": true
     },
     "@types/opn": {
       "version": "3.0.28",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/opn/-/opn-3.0.28.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/opn/-/opn-3.0.28.tgz",
       "integrity": "sha1-CX0NHJtXSVc6XZbfEyOHu20CEYo=",
       "dev": true,
       "requires": {
@@ -1142,13 +1142,13 @@
     },
     "@types/parse-json": {
       "version": "4.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/parse-json/-/parse-json-4.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha1-L4u0QUNNFjs1+4/9zNcTiSf/uMA=",
       "dev": true
     },
     "@types/parse5": {
       "version": "2.2.34",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/parse5/-/parse5-2.2.34.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/parse5/-/parse5-2.2.34.tgz",
       "integrity": "sha1-44cKEOgnNacg9i1x3NGDunjvOp0=",
       "dev": true,
       "requires": {
@@ -1157,13 +1157,13 @@
     },
     "@types/path-is-inside": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/path-is-inside/-/path-is-inside-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/path-is-inside/-/path-is-inside-1.0.0.tgz",
       "integrity": "sha1-Atb/OJddaEveyWIESUuvnynw4X8=",
       "dev": true
     },
     "@types/pem": {
       "version": "1.9.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/pem/-/pem-1.9.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/pem/-/pem-1.9.5.tgz",
       "integrity": "sha1-zVVIteCstLQaniEGfp/NjFcInJk=",
       "dev": true,
       "requires": {
@@ -1172,25 +1172,25 @@
     },
     "@types/qs": {
       "version": "6.9.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/qs/-/qs-6.9.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/qs/-/qs-6.9.3.tgz",
       "integrity": "sha1-t1Wgk0VkogDT79+IVG7JPDaavQM=",
       "dev": true
     },
     "@types/range-parser": {
       "version": "1.2.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/range-parser/-/range-parser-1.2.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/range-parser/-/range-parser-1.2.3.tgz",
       "integrity": "sha1-fuMwunyq+5gJC+zoal7kQRWQTCw=",
       "dev": true
     },
     "@types/relateurl": {
       "version": "0.2.28",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/relateurl/-/relateurl-0.2.28.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/relateurl/-/relateurl-0.2.28.tgz",
       "integrity": "sha1-a9p9uGU/piZD9e5p6facEaOS46Y=",
       "dev": true
     },
     "@types/resolve": {
       "version": "0.0.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/resolve/-/resolve-0.0.6.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/resolve/-/resolve-0.0.6.tgz",
       "integrity": "sha1-C9LyNsLhzruYt5iF31ft1xqNdw4=",
       "dev": true,
       "requires": {
@@ -1199,7 +1199,7 @@
     },
     "@types/serve-static": {
       "version": "1.13.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/serve-static/-/serve-static-1.13.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/serve-static/-/serve-static-1.13.4.tgz",
       "integrity": "sha1-ZmKpNYPlpsq8obI1kuuR4S+oDnw=",
       "dev": true,
       "requires": {
@@ -1209,7 +1209,7 @@
     },
     "@types/spdy": {
       "version": "3.4.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/spdy/-/spdy-3.4.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/spdy/-/spdy-3.4.4.tgz",
       "integrity": "sha1-MoL9StjEYDqkn3AX3VIKCKNFsrw=",
       "dev": true,
       "requires": {
@@ -1218,13 +1218,13 @@
     },
     "@types/ua-parser-js": {
       "version": "0.7.33",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/ua-parser-js/-/ua-parser-js-0.7.33.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/ua-parser-js/-/ua-parser-js-0.7.33.tgz",
       "integrity": "sha1-SpIIlRFXThKSiny2uZoBgxrNHdc=",
       "dev": true
     },
     "@types/uglify-js": {
       "version": "3.9.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/uglify-js/-/uglify-js-3.9.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/uglify-js/-/uglify-js-3.9.2.tgz",
       "integrity": "sha1-AZkled67pnTh41nNa8saHQqy4Cs=",
       "dev": true,
       "requires": {
@@ -1233,13 +1233,13 @@
     },
     "@types/uuid": {
       "version": "3.4.9",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/uuid/-/uuid-3.4.9.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/uuid/-/uuid-3.4.9.tgz",
       "integrity": "sha1-/PAZl7vJ98Ca5fkTg68HbUZllOE=",
       "dev": true
     },
     "@types/vinyl": {
       "version": "2.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/vinyl/-/vinyl-2.0.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/vinyl/-/vinyl-2.0.4.tgz",
       "integrity": "sha1-mnqAccjRTTqV1B6+cTW6vkrVmVo=",
       "dev": true,
       "requires": {
@@ -1249,7 +1249,7 @@
     },
     "@types/vinyl-fs": {
       "version": "2.4.11",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/vinyl-fs/-/vinyl-fs-2.4.11.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/vinyl-fs/-/vinyl-fs-2.4.11.tgz",
       "integrity": "sha1-uYEZuLsklBQer2SbCfv+sxEWEgY=",
       "dev": true,
       "requires": {
@@ -1260,7 +1260,7 @@
     },
     "@types/whatwg-url": {
       "version": "6.4.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/whatwg-url/-/whatwg-url-6.4.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/whatwg-url/-/whatwg-url-6.4.0.tgz",
       "integrity": "sha1-Hlm4xkvA299m0DfPhEnRw9UnAjc=",
       "dev": true,
       "requires": {
@@ -1269,14 +1269,14 @@
     },
     "@types/which": {
       "version": "1.3.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/which/-/which-1.3.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/which/-/which-1.3.2.tgz",
       "integrity": "sha1-nCRvwMk97TEchRLfKJH7QfYif98=",
       "dev": true,
       "optional": true
     },
     "@types/yauzl": {
       "version": "2.9.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/yauzl/-/yauzl-2.9.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/yauzl/-/yauzl-2.9.1.tgz",
       "integrity": "sha1-0Q9p+fUi7vPPmOMK+2hKHh7JI68=",
       "dev": true,
       "optional": true,
@@ -1286,31 +1286,31 @@
     },
     "@webcomponents/shadycss": {
       "version": "1.10.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@webcomponents/shadycss/-/shadycss-1.10.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@webcomponents/shadycss/-/shadycss-1.10.0.tgz",
       "integrity": "sha1-eoDsHosnH7PwzALNQ1i4d6MDVF0=",
       "dev": true
     },
     "@webcomponents/webcomponentsjs": {
       "version": "2.4.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@webcomponents/webcomponentsjs/-/webcomponentsjs-2.4.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@webcomponents/webcomponentsjs/-/webcomponentsjs-2.4.3.tgz",
       "integrity": "sha1-OE9PbVRWO6Rl+03yH+ieeKdvxTA=",
       "dev": true
     },
     "abab": {
       "version": "2.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/abab/-/abab-2.0.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/abab/-/abab-2.0.3.tgz",
       "integrity": "sha1-Yj4gdeAustPyR15J+ZyRhGRnkHo=",
       "dev": true
     },
     "abbrev": {
       "version": "1.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/abbrev/-/abbrev-1.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha1-+PLIh60Qv2f2NPAFtph/7TF5qsg=",
       "dev": true
     },
     "accepts": {
       "version": "1.3.7",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/accepts/-/accepts-1.3.7.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/accepts/-/accepts-1.3.7.tgz",
       "integrity": "sha1-UxvHJlF6OytB+FACHGzBXqq1B80=",
       "dev": true,
       "requires": {
@@ -1320,7 +1320,7 @@
     },
     "accessibility-developer-tools": {
       "version": "2.12.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/accessibility-developer-tools/-/accessibility-developer-tools-2.12.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/accessibility-developer-tools/-/accessibility-developer-tools-2.12.0.tgz",
       "integrity": "sha1-PaDM6dbsY3OWS4TzXbfPw996tRQ=",
       "dev": true
     },
@@ -1332,7 +1332,7 @@
     },
     "acorn-globals": {
       "version": "6.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/acorn-globals/-/acorn-globals-6.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/acorn-globals/-/acorn-globals-6.0.0.tgz",
       "integrity": "sha1-Rs3Tnw+P8IqHZhm1X1rIptx3C0U=",
       "dev": true,
       "requires": {
@@ -1342,31 +1342,31 @@
     },
     "acorn-jsx": {
       "version": "5.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/acorn-jsx/-/acorn-jsx-5.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/acorn-jsx/-/acorn-jsx-5.2.0.tgz",
       "integrity": "sha1-TGYGkXPW/daO2FI5/CViJhgrLr4=",
       "dev": true
     },
     "acorn-walk": {
       "version": "7.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/acorn-walk/-/acorn-walk-7.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/acorn-walk/-/acorn-walk-7.1.1.tgz",
       "integrity": "sha1-NF8N/61cc15zc9L+yaECPmpEuD4=",
       "dev": true
     },
     "adm-zip": {
       "version": "0.4.11",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/adm-zip/-/adm-zip-0.4.11.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/adm-zip/-/adm-zip-0.4.11.tgz",
       "integrity": "sha1-KqVMhMSwGp0PuJuxGYKlHxPj1io=",
       "dev": true
     },
     "after": {
       "version": "0.8.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/after/-/after-0.8.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/after/-/after-0.8.2.tgz",
       "integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8=",
       "dev": true
     },
     "agent-base": {
       "version": "4.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/agent-base/-/agent-base-4.3.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/agent-base/-/agent-base-4.3.0.tgz",
       "integrity": "sha1-gWXwHENgCbzK0LHRIvBe13Dvxu4=",
       "dev": true,
       "requires": {
@@ -1375,7 +1375,7 @@
     },
     "aggregate-error": {
       "version": "3.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/aggregate-error/-/aggregate-error-3.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/aggregate-error/-/aggregate-error-3.0.1.tgz",
       "integrity": "sha1-2y/nJG5Tb0DZtUQqOeEX191qJOA=",
       "dev": true,
       "requires": {
@@ -1385,7 +1385,7 @@
     },
     "ajv": {
       "version": "6.12.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ajv/-/ajv-6.12.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ajv/-/ajv-6.12.2.tgz",
       "integrity": "sha1-xinF7O0XuvMUQ3kY0tqIyZ1ZWM0=",
       "dev": true,
       "requires": {
@@ -1397,7 +1397,7 @@
     },
     "ansi-align": {
       "version": "3.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-align/-/ansi-align-3.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-align/-/ansi-align-3.0.0.tgz",
       "integrity": "sha1-tTazcc9ofKrvI2wY0+If43l0Z8s=",
       "dev": true,
       "requires": {
@@ -1406,25 +1406,25 @@
       "dependencies": {
         "ansi-regex": {
           "version": "4.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-4.1.0.tgz",
           "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc=",
           "dev": true
         },
         "emoji-regex": {
           "version": "7.0.3",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/emoji-regex/-/emoji-regex-7.0.3.tgz",
           "integrity": "sha1-kzoEBShgyF6DwSJHnEdIqOTHIVY=",
           "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
         "string-width": {
           "version": "3.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string-width/-/string-width-3.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/string-width/-/string-width-3.1.0.tgz",
           "integrity": "sha1-InZ74htirxCBV0MG9prFG2IgOWE=",
           "dev": true,
           "requires": {
@@ -1435,7 +1435,7 @@
         },
         "strip-ansi": {
           "version": "5.2.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
           "dev": true,
           "requires": {
@@ -1446,13 +1446,13 @@
     },
     "ansi-colors": {
       "version": "3.2.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-colors/-/ansi-colors-3.2.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-colors/-/ansi-colors-3.2.3.tgz",
       "integrity": "sha1-V9NbhoboUeLMBMQD8cACA5dqGBM=",
       "dev": true
     },
     "ansi-escapes": {
       "version": "4.3.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
       "integrity": "sha1-pcR8xDGB8fOP/XB2g3cA05VSKmE=",
       "dev": true,
       "requires": {
@@ -1461,7 +1461,7 @@
       "dependencies": {
         "type-fest": {
           "version": "0.11.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/type-fest/-/type-fest-0.11.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/type-fest/-/type-fest-0.11.0.tgz",
           "integrity": "sha1-l6vwhyMQ/tiKXEZrJWgVdhReM/E=",
           "dev": true
         }
@@ -1469,13 +1469,13 @@
     },
     "ansi-regex": {
       "version": "2.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-2.1.1.tgz",
       "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
       "dev": true
     },
     "ansi-styles": {
       "version": "3.2.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
       "dev": true,
       "requires": {
@@ -1484,19 +1484,19 @@
     },
     "any-observable": {
       "version": "0.5.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/any-observable/-/any-observable-0.5.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/any-observable/-/any-observable-0.5.1.tgz",
       "integrity": "sha1-q31J/2Tr5t064mdgo/WogejbeR4=",
       "dev": true
     },
     "any-promise": {
       "version": "1.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/any-promise/-/any-promise-1.3.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/any-promise/-/any-promise-1.3.0.tgz",
       "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8=",
       "dev": true
     },
     "anymatch": {
       "version": "3.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/anymatch/-/anymatch-3.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/anymatch/-/anymatch-3.1.1.tgz",
       "integrity": "sha1-xV7PAhheJGklk5kxDBc84xIzsUI=",
       "dev": true,
       "requires": {
@@ -1506,19 +1506,19 @@
     },
     "append-field": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/append-field/-/append-field-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/append-field/-/append-field-1.0.0.tgz",
       "integrity": "sha1-HjRA6RXwsSA9I3SOeO3XubW0PlY=",
       "dev": true
     },
     "aproba": {
       "version": "1.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/aproba/-/aproba-1.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/aproba/-/aproba-1.2.0.tgz",
       "integrity": "sha1-aALmJk79GMeQobDVF/DyYnvyyUo=",
       "dev": true
     },
     "archiver": {
       "version": "3.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/archiver/-/archiver-3.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/archiver/-/archiver-3.1.1.tgz",
       "integrity": "sha1-nbeBnU2vYK7BD+hrFsuSWM7WbqA=",
       "dev": true,
       "requires": {
@@ -1533,7 +1533,7 @@
       "dependencies": {
         "bl": {
           "version": "4.0.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/bl/-/bl-4.0.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/bl/-/bl-4.0.2.tgz",
           "integrity": "sha1-UrcekIhRXQYG2d2cx6pI3B+Y5zo=",
           "dev": true,
           "requires": {
@@ -1544,7 +1544,7 @@
         },
         "readable-stream": {
           "version": "3.6.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/readable-stream/-/readable-stream-3.6.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/readable-stream/-/readable-stream-3.6.0.tgz",
           "integrity": "sha1-M3u9o63AcGvT4CRCaihtS0sskZg=",
           "dev": true,
           "requires": {
@@ -1555,13 +1555,13 @@
         },
         "safe-buffer": {
           "version": "5.2.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/safe-buffer/-/safe-buffer-5.2.1.tgz",
           "integrity": "sha1-Hq+fqb2x/dTsdfWPnNtOa3gn7sY=",
           "dev": true
         },
         "string_decoder": {
           "version": "1.3.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string_decoder/-/string_decoder-1.3.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/string_decoder/-/string_decoder-1.3.0.tgz",
           "integrity": "sha1-QvEUWUpGzxqOMLCoT1bHjD7awh4=",
           "dev": true,
           "requires": {
@@ -1570,7 +1570,7 @@
         },
         "tar-stream": {
           "version": "2.1.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/tar-stream/-/tar-stream-2.1.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/tar-stream/-/tar-stream-2.1.2.tgz",
           "integrity": "sha1-bV7xp+V4OpX/cLabl0VaWWjcEyU=",
           "dev": true,
           "requires": {
@@ -1585,7 +1585,7 @@
     },
     "archiver-utils": {
       "version": "2.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/archiver-utils/-/archiver-utils-2.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/archiver-utils/-/archiver-utils-2.1.0.tgz",
       "integrity": "sha1-6KRg6UtpPD49oYKgmMpihbqSSeI=",
       "dev": true,
       "requires": {
@@ -1603,7 +1603,7 @@
     },
     "are-we-there-yet": {
       "version": "1.1.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
       "integrity": "sha1-SzXClE8GKov82mZBB2A1D+nd/CE=",
       "dev": true,
       "requires": {
@@ -1613,7 +1613,7 @@
     },
     "argparse": {
       "version": "1.0.10",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/argparse/-/argparse-1.0.10.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
       "dev": true,
       "requires": {
@@ -1622,79 +1622,79 @@
     },
     "arr-diff": {
       "version": "4.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/arr-diff/-/arr-diff-4.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/arr-diff/-/arr-diff-4.0.0.tgz",
       "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
       "dev": true
     },
     "arr-flatten": {
       "version": "1.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/arr-flatten/-/arr-flatten-1.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/arr-flatten/-/arr-flatten-1.1.0.tgz",
       "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE=",
       "dev": true
     },
     "arr-union": {
       "version": "3.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/arr-union/-/arr-union-3.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/arr-union/-/arr-union-3.1.0.tgz",
       "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
       "dev": true
     },
     "array-back": {
       "version": "3.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/array-back/-/array-back-3.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/array-back/-/array-back-3.1.0.tgz",
       "integrity": "sha1-uIWdelCIccmnss9C+ZQo9l6Wv7A=",
       "dev": true
     },
     "array-filter": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/array-filter/-/array-filter-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/array-filter/-/array-filter-1.0.0.tgz",
       "integrity": "sha1-uveeYubvTCpMC4MSMtr/7CUfnYM=",
       "dev": true
     },
     "array-find-index": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/array-find-index/-/array-find-index-1.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/array-find-index/-/array-find-index-1.0.2.tgz",
       "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
       "dev": true
     },
     "array-flatten": {
       "version": "1.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/array-flatten/-/array-flatten-1.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
       "dev": true
     },
     "array-union": {
       "version": "2.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/array-union/-/array-union-2.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/array-union/-/array-union-2.1.0.tgz",
       "integrity": "sha1-t5hCCtvrHego2ErNii4j0+/oXo0=",
       "dev": true
     },
     "array-uniq": {
       "version": "1.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/array-uniq/-/array-uniq-1.0.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/array-uniq/-/array-uniq-1.0.3.tgz",
       "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
       "dev": true
     },
     "array-unique": {
       "version": "0.3.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/array-unique/-/array-unique-0.3.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/array-unique/-/array-unique-0.3.2.tgz",
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
       "dev": true
     },
     "arraybuffer.slice": {
       "version": "0.0.7",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/arraybuffer.slice/-/arraybuffer.slice-0.0.7.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/arraybuffer.slice/-/arraybuffer.slice-0.0.7.tgz",
       "integrity": "sha1-O7xCdd1YTMGxCAm4nU6LY6aednU=",
       "dev": true
     },
     "arrify": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/arrify/-/arrify-1.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/arrify/-/arrify-1.0.1.tgz",
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
     },
     "asn1": {
       "version": "0.2.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/asn1/-/asn1-0.2.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/asn1/-/asn1-0.2.4.tgz",
       "integrity": "sha1-jSR136tVO7M+d7VOWeiAu4ziMTY=",
       "dev": true,
       "requires": {
@@ -1703,31 +1703,31 @@
     },
     "assert-plus": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/assert-plus/-/assert-plus-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
       "dev": true
     },
     "assertion-error": {
       "version": "1.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/assertion-error/-/assertion-error-1.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/assertion-error/-/assertion-error-1.1.0.tgz",
       "integrity": "sha1-5gtrDo8wG9l+U3UhW9pAbIURjAs=",
       "dev": true
     },
     "assign-symbols": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/assign-symbols/-/assign-symbols-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/assign-symbols/-/assign-symbols-1.0.0.tgz",
       "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
       "dev": true
     },
     "astral-regex": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/astral-regex/-/astral-regex-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/astral-regex/-/astral-regex-1.0.0.tgz",
       "integrity": "sha1-bIw/uCfdQ+45GPJ7gngqt2WKb9k=",
       "dev": true
     },
     "async": {
       "version": "2.6.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/async/-/async-2.6.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/async/-/async-2.6.3.tgz",
       "integrity": "sha1-1yYl4jRKNlbjo61Pp0n6gymdgv8=",
       "dev": true,
       "requires": {
@@ -1736,31 +1736,31 @@
     },
     "async-exit-hook": {
       "version": "2.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/async-exit-hook/-/async-exit-hook-2.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/async-exit-hook/-/async-exit-hook-2.0.1.tgz",
       "integrity": "sha1-i9iwJLDsmxwBzMua+dspvXF9+vM=",
       "dev": true
     },
     "async-limiter": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/async-limiter/-/async-limiter-1.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/async-limiter/-/async-limiter-1.0.1.tgz",
       "integrity": "sha1-3TeelPDbgxCwgpH51kwyCXZmF/0=",
       "dev": true
     },
     "asynckit": {
       "version": "0.4.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/asynckit/-/asynckit-0.4.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
     },
     "atob": {
       "version": "2.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/atob/-/atob-2.1.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/atob/-/atob-2.1.2.tgz",
       "integrity": "sha1-bZUX654DDSQ2ZmZR6GvZ9vE1M8k=",
       "dev": true
     },
     "available-typed-arrays": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/available-typed-arrays/-/available-typed-arrays-1.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/available-typed-arrays/-/available-typed-arrays-1.0.2.tgz",
       "integrity": "sha1-awmMqdgDkHnuP3f3t4PESAulE/U=",
       "dev": true,
       "requires": {
@@ -1769,19 +1769,19 @@
     },
     "aws-sign2": {
       "version": "0.7.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/aws-sign2/-/aws-sign2-0.7.0.tgz",
       "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
       "dev": true
     },
     "aws4": {
       "version": "1.10.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/aws4/-/aws4-1.10.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/aws4/-/aws4-1.10.0.tgz",
       "integrity": "sha1-oXs6jqgRBg501H0wYSJACtRJeuI=",
       "dev": true
     },
     "axios": {
       "version": "0.19.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/axios/-/axios-0.19.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/axios/-/axios-0.19.2.tgz",
       "integrity": "sha1-PqNsXYgY0NX4qKl6bTa4bNwAyyc=",
       "dev": true,
       "requires": {
@@ -1790,7 +1790,7 @@
     },
     "babel-code-frame": {
       "version": "6.26.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "dev": true,
       "requires": {
@@ -1801,13 +1801,13 @@
       "dependencies": {
         "ansi-styles": {
           "version": "2.2.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-styles/-/ansi-styles-2.2.1.tgz",
           "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
           "dev": true
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -1820,13 +1820,13 @@
         },
         "js-tokens": {
           "version": "3.0.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/js-tokens/-/js-tokens-3.0.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/js-tokens/-/js-tokens-3.0.2.tgz",
           "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
           "dev": true
         },
         "supports-color": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/supports-color/-/supports-color-2.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/supports-color/-/supports-color-2.0.0.tgz",
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         }
@@ -1834,7 +1834,7 @@
     },
     "babel-generator": {
       "version": "6.26.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-generator/-/babel-generator-6.26.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-generator/-/babel-generator-6.26.1.tgz",
       "integrity": "sha1-GERAjTuPDTWkBOp6wYDwh6YBvZA=",
       "dev": true,
       "requires": {
@@ -1850,13 +1850,13 @@
       "dependencies": {
         "jsesc": {
           "version": "1.3.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/jsesc/-/jsesc-1.3.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/jsesc/-/jsesc-1.3.0.tgz",
           "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
           "dev": true
         },
         "source-map": {
           "version": "0.5.7",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "dev": true
         }
@@ -1864,49 +1864,49 @@
     },
     "babel-helper-evaluate-path": {
       "version": "0.5.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-helper-evaluate-path/-/babel-helper-evaluate-path-0.5.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-helper-evaluate-path/-/babel-helper-evaluate-path-0.5.0.tgz",
       "integrity": "sha1-pi+pxOZP9+pc6pNTF07wI6kApnw=",
       "dev": true
     },
     "babel-helper-flip-expressions": {
       "version": "0.4.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-helper-flip-expressions/-/babel-helper-flip-expressions-0.4.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-helper-flip-expressions/-/babel-helper-flip-expressions-0.4.3.tgz",
       "integrity": "sha1-NpZzahKKwYvCUlS19AoizrPB0/0=",
       "dev": true
     },
     "babel-helper-is-nodes-equiv": {
       "version": "0.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-helper-is-nodes-equiv/-/babel-helper-is-nodes-equiv-0.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-helper-is-nodes-equiv/-/babel-helper-is-nodes-equiv-0.0.1.tgz",
       "integrity": "sha1-NOmzALFHnd2Y7HfqC76TQt/jloQ=",
       "dev": true
     },
     "babel-helper-is-void-0": {
       "version": "0.4.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-helper-is-void-0/-/babel-helper-is-void-0-0.4.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-helper-is-void-0/-/babel-helper-is-void-0-0.4.3.tgz",
       "integrity": "sha1-fZwBtFYee5Xb2g9u7kj1tg5nMT4=",
       "dev": true
     },
     "babel-helper-mark-eval-scopes": {
       "version": "0.4.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-helper-mark-eval-scopes/-/babel-helper-mark-eval-scopes-0.4.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-helper-mark-eval-scopes/-/babel-helper-mark-eval-scopes-0.4.3.tgz",
       "integrity": "sha1-0kSjvvmESHJgP/tG4izorN9VFWI=",
       "dev": true
     },
     "babel-helper-remove-or-void": {
       "version": "0.4.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-helper-remove-or-void/-/babel-helper-remove-or-void-0.4.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-helper-remove-or-void/-/babel-helper-remove-or-void-0.4.3.tgz",
       "integrity": "sha1-pPA7QAd6D/6I5F0HAQ3uJB/1rmA=",
       "dev": true
     },
     "babel-helper-to-multiple-sequence-expressions": {
       "version": "0.5.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-helper-to-multiple-sequence-expressions/-/babel-helper-to-multiple-sequence-expressions-0.5.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-helper-to-multiple-sequence-expressions/-/babel-helper-to-multiple-sequence-expressions-0.5.0.tgz",
       "integrity": "sha1-o/kk41YYgtQvz0iQeqmPeXmkWI0=",
       "dev": true
     },
     "babel-messages": {
       "version": "6.23.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-messages/-/babel-messages-6.23.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-messages/-/babel-messages-6.23.0.tgz",
       "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
       "dev": true,
       "requires": {
@@ -1915,7 +1915,7 @@
     },
     "babel-plugin-dynamic-import-node": {
       "version": "2.3.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz",
       "integrity": "sha1-hP2hnJduxcbe/vV/lCez3vZuF6M=",
       "dev": true,
       "requires": {
@@ -1924,13 +1924,13 @@
     },
     "babel-plugin-minify-builtins": {
       "version": "0.5.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-minify-builtins/-/babel-plugin-minify-builtins-0.5.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-plugin-minify-builtins/-/babel-plugin-minify-builtins-0.5.0.tgz",
       "integrity": "sha1-MeuC7RoNDv3DExL5O25HQc6Cw2s=",
       "dev": true
     },
     "babel-plugin-minify-constant-folding": {
       "version": "0.5.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-minify-constant-folding/-/babel-plugin-minify-constant-folding-0.5.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-plugin-minify-constant-folding/-/babel-plugin-minify-constant-folding-0.5.0.tgz",
       "integrity": "sha1-+EvI2/alYeXjUP+VriFrCtVRW24=",
       "dev": true,
       "requires": {
@@ -1939,7 +1939,7 @@
     },
     "babel-plugin-minify-dead-code-elimination": {
       "version": "0.5.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-minify-dead-code-elimination/-/babel-plugin-minify-dead-code-elimination-0.5.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-plugin-minify-dead-code-elimination/-/babel-plugin-minify-dead-code-elimination-0.5.1.tgz",
       "integrity": "sha1-Ggxo5EvjDeSXbKaf/FNeCL4TaD8=",
       "dev": true,
       "requires": {
@@ -1951,7 +1951,7 @@
     },
     "babel-plugin-minify-flip-comparisons": {
       "version": "0.4.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-minify-flip-comparisons/-/babel-plugin-minify-flip-comparisons-0.4.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-plugin-minify-flip-comparisons/-/babel-plugin-minify-flip-comparisons-0.4.3.tgz",
       "integrity": "sha1-AMqHDLjxO0XAOLPB68DyJyk8llo=",
       "dev": true,
       "requires": {
@@ -1960,7 +1960,7 @@
     },
     "babel-plugin-minify-guarded-expressions": {
       "version": "0.4.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-minify-guarded-expressions/-/babel-plugin-minify-guarded-expressions-0.4.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-plugin-minify-guarded-expressions/-/babel-plugin-minify-guarded-expressions-0.4.4.tgz",
       "integrity": "sha1-gYlg9kzAiu6dbHW+xtqXTE1iETU=",
       "dev": true,
       "requires": {
@@ -1970,13 +1970,13 @@
     },
     "babel-plugin-minify-infinity": {
       "version": "0.4.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-minify-infinity/-/babel-plugin-minify-infinity-0.4.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-plugin-minify-infinity/-/babel-plugin-minify-infinity-0.4.3.tgz",
       "integrity": "sha1-37h2obCKBldjhO8/kuZTumB7Oco=",
       "dev": true
     },
     "babel-plugin-minify-mangle-names": {
       "version": "0.5.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-minify-mangle-names/-/babel-plugin-minify-mangle-names-0.5.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-plugin-minify-mangle-names/-/babel-plugin-minify-mangle-names-0.5.0.tgz",
       "integrity": "sha1-vN21B8kdLJnhOL1rF6GcPCceP9M=",
       "dev": true,
       "requires": {
@@ -1985,19 +1985,19 @@
     },
     "babel-plugin-minify-numeric-literals": {
       "version": "0.4.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-minify-numeric-literals/-/babel-plugin-minify-numeric-literals-0.4.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-plugin-minify-numeric-literals/-/babel-plugin-minify-numeric-literals-0.4.3.tgz",
       "integrity": "sha1-jk/VYcefeAEob/YOjF/Z3u6TwLw=",
       "dev": true
     },
     "babel-plugin-minify-replace": {
       "version": "0.5.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-minify-replace/-/babel-plugin-minify-replace-0.5.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-plugin-minify-replace/-/babel-plugin-minify-replace-0.5.0.tgz",
       "integrity": "sha1-0+LJlGyQlsBw78lnYc4ojsXD9xw=",
       "dev": true
     },
     "babel-plugin-minify-simplify": {
       "version": "0.5.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-minify-simplify/-/babel-plugin-minify-simplify-0.5.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-plugin-minify-simplify/-/babel-plugin-minify-simplify-0.5.1.tgz",
       "integrity": "sha1-8hYTyLla80UKLKcVAv29kXk8jWo=",
       "dev": true,
       "requires": {
@@ -2009,7 +2009,7 @@
     },
     "babel-plugin-minify-type-constructors": {
       "version": "0.4.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-minify-type-constructors/-/babel-plugin-minify-type-constructors-0.4.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-plugin-minify-type-constructors/-/babel-plugin-minify-type-constructors-0.4.3.tgz",
       "integrity": "sha1-G8bxW4f3qxCF1CszC3F2V6IVZQA=",
       "dev": true,
       "requires": {
@@ -2018,31 +2018,31 @@
     },
     "babel-plugin-transform-inline-consecutive-adds": {
       "version": "0.4.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-transform-inline-consecutive-adds/-/babel-plugin-transform-inline-consecutive-adds-0.4.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-plugin-transform-inline-consecutive-adds/-/babel-plugin-transform-inline-consecutive-adds-0.4.3.tgz",
       "integrity": "sha1-Mj1Ho+pjqDp6w8gRro5pQfrysNE=",
       "dev": true
     },
     "babel-plugin-transform-member-expression-literals": {
       "version": "6.9.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-transform-member-expression-literals/-/babel-plugin-transform-member-expression-literals-6.9.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-plugin-transform-member-expression-literals/-/babel-plugin-transform-member-expression-literals-6.9.4.tgz",
       "integrity": "sha1-NwOcmgwzE6OUlfqsL/OmtbnQOL8=",
       "dev": true
     },
     "babel-plugin-transform-merge-sibling-variables": {
       "version": "6.9.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-transform-merge-sibling-variables/-/babel-plugin-transform-merge-sibling-variables-6.9.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-plugin-transform-merge-sibling-variables/-/babel-plugin-transform-merge-sibling-variables-6.9.4.tgz",
       "integrity": "sha1-hbQi/DN3tEnJ0c3kQIcgNTJAHa4=",
       "dev": true
     },
     "babel-plugin-transform-minify-booleans": {
       "version": "6.9.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-transform-minify-booleans/-/babel-plugin-transform-minify-booleans-6.9.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-plugin-transform-minify-booleans/-/babel-plugin-transform-minify-booleans-6.9.4.tgz",
       "integrity": "sha1-rLs+VqNVXdI5KOS1gtKFFi3SsZg=",
       "dev": true
     },
     "babel-plugin-transform-property-literals": {
       "version": "6.9.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-transform-property-literals/-/babel-plugin-transform-property-literals-6.9.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-plugin-transform-property-literals/-/babel-plugin-transform-property-literals-6.9.4.tgz",
       "integrity": "sha1-mMHSHiVXNlc/k+zlRFn2ziSYXTk=",
       "dev": true,
       "requires": {
@@ -2051,25 +2051,25 @@
     },
     "babel-plugin-transform-regexp-constructors": {
       "version": "0.4.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-transform-regexp-constructors/-/babel-plugin-transform-regexp-constructors-0.4.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-plugin-transform-regexp-constructors/-/babel-plugin-transform-regexp-constructors-0.4.3.tgz",
       "integrity": "sha1-WLd3W2OvzzMyj66aX4j71PsLSWU=",
       "dev": true
     },
     "babel-plugin-transform-remove-console": {
       "version": "6.9.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-transform-remove-console/-/babel-plugin-transform-remove-console-6.9.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-plugin-transform-remove-console/-/babel-plugin-transform-remove-console-6.9.4.tgz",
       "integrity": "sha1-uYA2DAZzhOJLNXpYjYB9PINSd4A=",
       "dev": true
     },
     "babel-plugin-transform-remove-debugger": {
       "version": "6.9.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-transform-remove-debugger/-/babel-plugin-transform-remove-debugger-6.9.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-plugin-transform-remove-debugger/-/babel-plugin-transform-remove-debugger-6.9.4.tgz",
       "integrity": "sha1-QrcnYxyXl44estGZp67IShgznvI=",
       "dev": true
     },
     "babel-plugin-transform-remove-undefined": {
       "version": "0.5.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-transform-remove-undefined/-/babel-plugin-transform-remove-undefined-0.5.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-plugin-transform-remove-undefined/-/babel-plugin-transform-remove-undefined-0.5.0.tgz",
       "integrity": "sha1-gCCLMSJXZsYwyX+i0oiVIFbqIt0=",
       "dev": true,
       "requires": {
@@ -2078,19 +2078,19 @@
     },
     "babel-plugin-transform-simplify-comparison-operators": {
       "version": "6.9.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-transform-simplify-comparison-operators/-/babel-plugin-transform-simplify-comparison-operators-6.9.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-plugin-transform-simplify-comparison-operators/-/babel-plugin-transform-simplify-comparison-operators-6.9.4.tgz",
       "integrity": "sha1-9ir+CWyrDh9ootdT/fKDiIRxzrk=",
       "dev": true
     },
     "babel-plugin-transform-undefined-to-void": {
       "version": "6.9.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-plugin-transform-undefined-to-void/-/babel-plugin-transform-undefined-to-void-6.9.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-plugin-transform-undefined-to-void/-/babel-plugin-transform-undefined-to-void-6.9.4.tgz",
       "integrity": "sha1-viQcqBQEAwZ4t0hxcyK4nQyP4oA=",
       "dev": true
     },
     "babel-preset-minify": {
       "version": "0.5.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-preset-minify/-/babel-preset-minify-0.5.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-preset-minify/-/babel-preset-minify-0.5.1.tgz",
       "integrity": "sha1-JfXQvONuyBi+gDONDllBBuIeqp8=",
       "dev": true,
       "requires": {
@@ -2121,7 +2121,7 @@
     },
     "babel-runtime": {
       "version": "6.26.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "dev": true,
       "requires": {
@@ -2131,7 +2131,7 @@
       "dependencies": {
         "core-js": {
           "version": "2.6.11",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/core-js/-/core-js-2.6.11.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/core-js/-/core-js-2.6.11.tgz",
           "integrity": "sha1-OIMUafmSK97Y7iHJ3EaYXgOZMIw=",
           "dev": true
         }
@@ -2139,7 +2139,7 @@
     },
     "babel-traverse": {
       "version": "6.26.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-traverse/-/babel-traverse-6.26.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-traverse/-/babel-traverse-6.26.0.tgz",
       "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
       "dev": true,
       "requires": {
@@ -2156,13 +2156,13 @@
       "dependencies": {
         "babylon": {
           "version": "6.18.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babylon/-/babylon-6.18.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babylon/-/babylon-6.18.0.tgz",
           "integrity": "sha1-ry87iPpvXB5MY00aD46sT1WzleM=",
           "dev": true
         },
         "debug": {
           "version": "2.6.9",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-2.6.9.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/debug/-/debug-2.6.9.tgz",
           "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
           "dev": true,
           "requires": {
@@ -2171,7 +2171,7 @@
         },
         "globals": {
           "version": "9.18.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/globals/-/globals-9.18.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/globals/-/globals-9.18.0.tgz",
           "integrity": "sha1-qjiWs+abSH8X4x7SFD1pqOMMLYo=",
           "dev": true
         }
@@ -2179,7 +2179,7 @@
     },
     "babel-types": {
       "version": "6.26.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babel-types/-/babel-types-6.26.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babel-types/-/babel-types-6.26.0.tgz",
       "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
       "dev": true,
       "requires": {
@@ -2191,7 +2191,7 @@
       "dependencies": {
         "to-fast-properties": {
           "version": "1.0.3",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
           "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
           "dev": true
         }
@@ -2199,25 +2199,25 @@
     },
     "babylon": {
       "version": "7.0.0-beta.47",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/babylon/-/babylon-7.0.0-beta.47.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/babylon/-/babylon-7.0.0-beta.47.tgz",
       "integrity": "sha1-bR+kTwq+xBq3x4BIHmL9mq+96oA=",
       "dev": true
     },
     "backo2": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/backo2/-/backo2-1.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/backo2/-/backo2-1.0.2.tgz",
       "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc=",
       "dev": true
     },
     "balanced-match": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/balanced-match/-/balanced-match-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
     "base": {
       "version": "0.11.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/base/-/base-0.11.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/base/-/base-0.11.2.tgz",
       "integrity": "sha1-e95c7RRbbVUakNuH+DxVi060io8=",
       "dev": true,
       "requires": {
@@ -2232,7 +2232,7 @@
       "dependencies": {
         "define-property": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/define-property/-/define-property-1.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
@@ -2241,7 +2241,7 @@
         },
         "is-accessor-descriptor": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
           "dev": true,
           "requires": {
@@ -2250,7 +2250,7 @@
         },
         "is-data-descriptor": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
           "dev": true,
           "requires": {
@@ -2259,7 +2259,7 @@
         },
         "is-descriptor": {
           "version": "1.0.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
           "dev": true,
           "requires": {
@@ -2272,31 +2272,31 @@
     },
     "base64-arraybuffer": {
       "version": "0.1.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
       "integrity": "sha1-c5JncZI7Whl0etZmqlzUv5xunOg=",
       "dev": true
     },
     "base64-js": {
       "version": "1.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/base64-js/-/base64-js-1.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/base64-js/-/base64-js-1.2.0.tgz",
       "integrity": "sha1-o5mS1yNYSBGYK+XikLtqU9hnAPE=",
       "dev": true
     },
     "base64id": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/base64id/-/base64id-2.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/base64id/-/base64id-2.0.0.tgz",
       "integrity": "sha1-J3Csa8R9MSr5eov5pjQ0LgzSXLY=",
       "dev": true
     },
     "basic-auth": {
       "version": "1.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/basic-auth/-/basic-auth-1.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/basic-auth/-/basic-auth-1.1.0.tgz",
       "integrity": "sha1-RSIe5Cn37h5QNb4/UVM/HN/SmIQ=",
       "dev": true
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "dev": true,
       "requires": {
@@ -2305,7 +2305,7 @@
     },
     "better-assert": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/better-assert/-/better-assert-1.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/better-assert/-/better-assert-1.0.2.tgz",
       "integrity": "sha1-QIZrnhueC1W0gYlDEeaPr/rrxSI=",
       "dev": true,
       "requires": {
@@ -2314,13 +2314,13 @@
     },
     "binary-extensions": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/binary-extensions/-/binary-extensions-2.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/binary-extensions/-/binary-extensions-2.0.0.tgz",
       "integrity": "sha1-I8DfFPaogHf1+YbA0WfsA8PVU3w=",
       "dev": true
     },
     "bindings": {
       "version": "1.5.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/bindings/-/bindings-1.5.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/bindings/-/bindings-1.5.0.tgz",
       "integrity": "sha1-EDU8npRTNLwFEabZCzj7x8nFBN8=",
       "dev": true,
       "requires": {
@@ -2329,7 +2329,7 @@
     },
     "bl": {
       "version": "2.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/bl/-/bl-2.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/bl/-/bl-2.2.0.tgz",
       "integrity": "sha1-4aV0zfUo5AUwGbuACwQcCsiNpJM=",
       "dev": true,
       "optional": true,
@@ -2340,13 +2340,13 @@
     },
     "blob": {
       "version": "0.0.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/blob/-/blob-0.0.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/blob/-/blob-0.0.5.tgz",
       "integrity": "sha1-1oDu7yX4zZGtUz9bAe7UjmTK9oM=",
       "dev": true
     },
     "block-stream": {
       "version": "0.0.9",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/block-stream/-/block-stream-0.0.9.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/block-stream/-/block-stream-0.0.9.tgz",
       "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
       "dev": true,
       "requires": {
@@ -2355,13 +2355,13 @@
     },
     "bluebird": {
       "version": "3.4.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/bluebird/-/bluebird-3.4.6.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/bluebird/-/bluebird-3.4.6.tgz",
       "integrity": "sha1-AdqNgh2HgT0ViWfnQ9X+bGLPjA8=",
       "dev": true
     },
     "body-parser": {
       "version": "1.19.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/body-parser/-/body-parser-1.19.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/body-parser/-/body-parser-1.19.0.tgz",
       "integrity": "sha1-lrJwnlfJxOCab9Zqj9l5hE9p8Io=",
       "dev": true,
       "requires": {
@@ -2379,7 +2379,7 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-2.6.9.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/debug/-/debug-2.6.9.tgz",
           "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
           "dev": true,
           "requires": {
@@ -2388,7 +2388,7 @@
         },
         "qs": {
           "version": "6.7.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/qs/-/qs-6.7.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/qs/-/qs-6.7.0.tgz",
           "integrity": "sha1-QdwaAV49WB8WIXdr4xr7KHapsbw=",
           "dev": true
         }
@@ -2396,7 +2396,7 @@
     },
     "bower-config": {
       "version": "1.4.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/bower-config/-/bower-config-1.4.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/bower-config/-/bower-config-1.4.3.tgz",
       "integrity": "sha1-NFT+zcXwjnqpzG1Vbkkr4GaWia4=",
       "dev": true,
       "requires": {
@@ -2410,13 +2410,13 @@
       "dependencies": {
         "minimist": {
           "version": "0.2.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/minimist/-/minimist-0.2.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/minimist/-/minimist-0.2.1.tgz",
           "integrity": "sha1-gnuk51k0ZOfCIejFvtkwkE7ixFU=",
           "dev": true
         },
         "wordwrap": {
           "version": "0.0.3",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/wordwrap/-/wordwrap-0.0.3.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/wordwrap/-/wordwrap-0.0.3.tgz",
           "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
           "dev": true
         }
@@ -2424,7 +2424,7 @@
     },
     "boxen": {
       "version": "4.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/boxen/-/boxen-4.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/boxen/-/boxen-4.2.0.tgz",
       "integrity": "sha1-5BG2I1fW1tNlh8isPV2XTaoHDmQ=",
       "dev": true,
       "requires": {
@@ -2440,13 +2440,13 @@
       "dependencies": {
         "ansi-regex": {
           "version": "5.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-5.0.0.tgz",
           "integrity": "sha1-OIU59VF5vzkznIGvMKZU1p+Hy3U=",
           "dev": true
         },
         "ansi-styles": {
           "version": "4.2.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-styles/-/ansi-styles-4.2.1.tgz",
           "integrity": "sha1-kK51xCTQCNJiTFvynq0xd+v881k=",
           "dev": true,
           "requires": {
@@ -2456,7 +2456,7 @@
         },
         "chalk": {
           "version": "3.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/chalk/-/chalk-3.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/chalk/-/chalk-3.0.0.tgz",
           "integrity": "sha1-P3PCv1JlkfV0zEksUeJFY0n4ROQ=",
           "dev": true,
           "requires": {
@@ -2466,7 +2466,7 @@
         },
         "color-convert": {
           "version": "2.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/color-convert/-/color-convert-2.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/color-convert/-/color-convert-2.0.1.tgz",
           "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
           "dev": true,
           "requires": {
@@ -2475,25 +2475,25 @@
         },
         "color-name": {
           "version": "1.1.4",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/color-name/-/color-name-1.1.4.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
           "dev": true
         },
         "has-flag": {
           "version": "4.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/has-flag/-/has-flag-4.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
           "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "3.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
           "integrity": "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0=",
           "dev": true
         },
         "string-width": {
           "version": "4.2.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string-width/-/string-width-4.2.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/string-width/-/string-width-4.2.0.tgz",
           "integrity": "sha1-lSGCxGzHssMT0VluYjmSvRY7crU=",
           "dev": true,
           "requires": {
@@ -2504,7 +2504,7 @@
         },
         "strip-ansi": {
           "version": "6.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-6.0.0.tgz",
           "integrity": "sha1-CxVx3XZpzNTz4G4U7x7tJiJa5TI=",
           "dev": true,
           "requires": {
@@ -2513,7 +2513,7 @@
         },
         "supports-color": {
           "version": "7.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/supports-color/-/supports-color-7.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/supports-color/-/supports-color-7.1.0.tgz",
           "integrity": "sha1-aOMlkd9z4lrRxLSRCKLsUHliv9E=",
           "dev": true,
           "requires": {
@@ -2524,7 +2524,7 @@
     },
     "brace-expansion": {
       "version": "1.1.11",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
       "dev": true,
       "requires": {
@@ -2534,7 +2534,7 @@
     },
     "braces": {
       "version": "3.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/braces/-/braces-3.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/braces/-/braces-3.0.2.tgz",
       "integrity": "sha1-NFThpGLujVmeI23zNs2epPiv4Qc=",
       "dev": true,
       "requires": {
@@ -2543,7 +2543,7 @@
     },
     "browser-capabilities": {
       "version": "1.1.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/browser-capabilities/-/browser-capabilities-1.1.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/browser-capabilities/-/browser-capabilities-1.1.4.tgz",
       "integrity": "sha1-pr1legehNFMq1mxyK4lJkER4uXM=",
       "dev": true,
       "requires": {
@@ -2553,19 +2553,19 @@
     },
     "browser-process-hrtime": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
       "integrity": "sha1-PJtLfXgsgSHlbxAQbYTA0P/JRiY=",
       "dev": true
     },
     "browser-stdout": {
       "version": "1.3.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/browser-stdout/-/browser-stdout-1.3.1.tgz",
       "integrity": "sha1-uqVZ7hTO1zRSIputcyZGfGH6vWA=",
       "dev": true
     },
     "browserstack": {
       "version": "1.6.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/browserstack/-/browserstack-1.6.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/browserstack/-/browserstack-1.6.0.tgz",
       "integrity": "sha1-WlarkJh2BdnBONeouIEoNwKX+b8=",
       "dev": true,
       "optional": true,
@@ -2575,7 +2575,7 @@
       "dependencies": {
         "https-proxy-agent": {
           "version": "2.2.4",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
           "integrity": "sha1-TuenN6vZJniik9mzShr00NCMeHs=",
           "dev": true,
           "optional": true,
@@ -2588,7 +2588,7 @@
     },
     "buffer": {
       "version": "5.6.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/buffer/-/buffer-5.6.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/buffer/-/buffer-5.6.0.tgz",
       "integrity": "sha1-oxdJ3H2B2E2wir+Te2uMQDP2J4Y=",
       "dev": true,
       "requires": {
@@ -2598,19 +2598,19 @@
     },
     "buffer-crc32": {
       "version": "0.2.13",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
       "dev": true
     },
     "buffer-from": {
       "version": "1.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/buffer-from/-/buffer-from-1.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/buffer-from/-/buffer-from-1.1.1.tgz",
       "integrity": "sha1-MnE7wCj3XAL9txDXx7zsHyxgcO8=",
       "dev": true
     },
     "bufferstreams": {
       "version": "1.1.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/bufferstreams/-/bufferstreams-1.1.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/bufferstreams/-/bufferstreams-1.1.3.tgz",
       "integrity": "sha1-qFFawCT6kOj6fVjBGxPeofKKvnI=",
       "dev": true,
       "requires": {
@@ -2619,13 +2619,13 @@
     },
     "builtins": {
       "version": "1.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/builtins/-/builtins-1.0.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/builtins/-/builtins-1.0.3.tgz",
       "integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og=",
       "dev": true
     },
     "busboy": {
       "version": "0.2.14",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/busboy/-/busboy-0.2.14.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/busboy/-/busboy-0.2.14.tgz",
       "integrity": "sha1-bCpiLvz0fFe7vh4qnDetNseSVFM=",
       "dev": true,
       "requires": {
@@ -2635,7 +2635,7 @@
       "dependencies": {
         "readable-stream": {
           "version": "1.1.14",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/readable-stream/-/readable-stream-1.1.14.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
@@ -2649,13 +2649,13 @@
     },
     "bytes": {
       "version": "3.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/bytes/-/bytes-3.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/bytes/-/bytes-3.1.0.tgz",
       "integrity": "sha1-9s95M6Ng4FiPqf3oVlHNx/gF0fY=",
       "dev": true
     },
     "cache-base": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cache-base/-/cache-base-1.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/cache-base/-/cache-base-1.0.1.tgz",
       "integrity": "sha1-Cn9GQWgxyLZi7jb+TnxZ129marI=",
       "dev": true,
       "requires": {
@@ -2672,7 +2672,7 @@
     },
     "cacheable-request": {
       "version": "6.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cacheable-request/-/cacheable-request-6.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/cacheable-request/-/cacheable-request-6.1.0.tgz",
       "integrity": "sha1-IP+4vRYrpL4R6VZ9gj22UQUsqRI=",
       "dev": true,
       "requires": {
@@ -2687,7 +2687,7 @@
       "dependencies": {
         "lowercase-keys": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
           "integrity": "sha1-JgPni3tLAAbLyi+8yKMgJVislHk=",
           "dev": true
         }
@@ -2695,19 +2695,19 @@
     },
     "callsite": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/callsite/-/callsite-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/callsite/-/callsite-1.0.0.tgz",
       "integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA=",
       "dev": true
     },
     "callsites": {
       "version": "3.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/callsites/-/callsites-3.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha1-s2MKvYlDQy9Us/BRkjjjPNffL3M=",
       "dev": true
     },
     "camel-case": {
       "version": "3.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/camel-case/-/camel-case-3.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/camel-case/-/camel-case-3.0.0.tgz",
       "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
       "dev": true,
       "requires": {
@@ -2717,13 +2717,13 @@
     },
     "camelcase": {
       "version": "5.3.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/camelcase/-/camelcase-5.3.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/camelcase/-/camelcase-5.3.1.tgz",
       "integrity": "sha1-48mzFWnhBoEd8kL3FXJaH0xJQyA=",
       "dev": true
     },
     "camelcase-keys": {
       "version": "6.2.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
       "integrity": "sha1-XnVda6UaoiPsfT1S8ld4IQ+dw8A=",
       "dev": true,
       "requires": {
@@ -2734,7 +2734,7 @@
     },
     "cancel-token": {
       "version": "0.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cancel-token/-/cancel-token-0.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/cancel-token/-/cancel-token-0.1.1.tgz",
       "integrity": "sha1-wYGXZ0uxyEwdaTPr8V2NWlznm08=",
       "dev": true,
       "requires": {
@@ -2743,7 +2743,7 @@
       "dependencies": {
         "@types/node": {
           "version": "4.9.4",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/node/-/node-4.9.4.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/node/-/node-4.9.4.tgz",
           "integrity": "sha1-de+Rczr6qFawHhLabs9Iqp1eIh8=",
           "dev": true
         }
@@ -2751,19 +2751,19 @@
     },
     "capture-stack-trace": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz",
       "integrity": "sha1-psC74fOPOqC5Ijjstv9Cw0TUE10=",
       "dev": true
     },
     "caseless": {
       "version": "0.12.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/caseless/-/caseless-0.12.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
       "dev": true
     },
     "chai": {
       "version": "4.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/chai/-/chai-4.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/chai/-/chai-4.2.0.tgz",
       "integrity": "sha1-dgqnLPION5XoSxKHfODoNzeqKeU=",
       "dev": true,
       "requires": {
@@ -2777,7 +2777,7 @@
     },
     "chai-as-promised": {
       "version": "7.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
       "integrity": "sha1-CGRdgl3rhpbuYXJdv1kMAS6wDKA=",
       "dev": true,
       "requires": {
@@ -2838,25 +2838,25 @@
     },
     "chardet": {
       "version": "0.7.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/chardet/-/chardet-0.7.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha1-kAlISfCTfy7twkJdDSip5fDLrZ4=",
       "dev": true
     },
     "charenc": {
       "version": "0.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/charenc/-/charenc-0.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/charenc/-/charenc-0.0.2.tgz",
       "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=",
       "dev": true
     },
     "check-error": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/check-error/-/check-error-1.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/check-error/-/check-error-1.0.2.tgz",
       "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
       "dev": true
     },
     "chokidar": {
       "version": "3.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/chokidar/-/chokidar-3.3.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/chokidar/-/chokidar-3.3.0.tgz",
       "integrity": "sha1-EsBxRmjFWAD2WeJi1JYql/r1VKY=",
       "dev": true,
       "requires": {
@@ -2872,13 +2872,13 @@
     },
     "chownr": {
       "version": "1.1.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/chownr/-/chownr-1.1.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/chownr/-/chownr-1.1.4.tgz",
       "integrity": "sha1-b8nXtC0ypYNZYzdmbn0ICE2izGs=",
       "dev": true
     },
     "chromedriver": {
       "version": "83.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/chromedriver/-/chromedriver-83.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/chromedriver/-/chromedriver-83.0.0.tgz",
       "integrity": "sha1-ddfYOOWAFGWMOZAIlGQWb++VGSY=",
       "dev": true,
       "requires": {
@@ -2892,7 +2892,7 @@
       "dependencies": {
         "mkdirp": {
           "version": "1.0.4",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mkdirp/-/mkdirp-1.0.4.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/mkdirp/-/mkdirp-1.0.4.tgz",
           "integrity": "sha1-PrXtYmInVteaXw4qIh3+utdcL34=",
           "dev": true
         }
@@ -2900,13 +2900,13 @@
     },
     "ci-info": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ci-info/-/ci-info-2.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ci-info/-/ci-info-2.0.0.tgz",
       "integrity": "sha1-Z6npZL4xpR4V5QENWObxKDQAL0Y=",
       "dev": true
     },
     "class-utils": {
       "version": "0.3.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/class-utils/-/class-utils-0.3.6.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/class-utils/-/class-utils-0.3.6.tgz",
       "integrity": "sha1-+TNprouafOAv1B+q0MqDAzGQxGM=",
       "dev": true,
       "requires": {
@@ -2918,7 +2918,7 @@
       "dependencies": {
         "define-property": {
           "version": "0.2.5",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/define-property/-/define-property-0.2.5.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
@@ -2929,13 +2929,13 @@
     },
     "classlist-polyfill": {
       "version": "1.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/classlist-polyfill/-/classlist-polyfill-1.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/classlist-polyfill/-/classlist-polyfill-1.2.0.tgz",
       "integrity": "sha1-k1vC39lFiodrJ5YXUUY4vKqWSi4=",
       "dev": true
     },
     "clean-css": {
       "version": "4.2.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/clean-css/-/clean-css-4.2.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/clean-css/-/clean-css-4.2.3.tgz",
       "integrity": "sha1-UHtd59l7SO5T2ErbAWD/YhY4D3g=",
       "dev": true,
       "requires": {
@@ -2944,25 +2944,25 @@
     },
     "clean-stack": {
       "version": "2.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/clean-stack/-/clean-stack-2.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/clean-stack/-/clean-stack-2.2.0.tgz",
       "integrity": "sha1-7oRy27Ep5yezHooQpCfe6d/kAIs=",
       "dev": true
     },
     "cleankill": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cleankill/-/cleankill-2.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/cleankill/-/cleankill-2.0.0.tgz",
       "integrity": "sha1-WYMN/ItBHVPccq0J1Fp46jMWGpE=",
       "dev": true
     },
     "cli-boxes": {
       "version": "2.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cli-boxes/-/cli-boxes-2.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/cli-boxes/-/cli-boxes-2.2.0.tgz",
       "integrity": "sha1-U47K6PnGylCOPDyVtFP+k8tMFo0=",
       "dev": true
     },
     "cli-cursor": {
       "version": "3.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/cli-cursor/-/cli-cursor-3.1.0.tgz",
       "integrity": "sha1-JkMFp65JDR0Dvwybp8kl0XU68wc=",
       "dev": true,
       "requires": {
@@ -2971,7 +2971,7 @@
     },
     "cli-truncate": {
       "version": "0.2.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cli-truncate/-/cli-truncate-0.2.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/cli-truncate/-/cli-truncate-0.2.1.tgz",
       "integrity": "sha1-nxXPuwcFAFNpIWxiasfQWrkN1XQ=",
       "dev": true,
       "requires": {
@@ -2981,7 +2981,7 @@
       "dependencies": {
         "slice-ansi": {
           "version": "0.0.4",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/slice-ansi/-/slice-ansi-0.0.4.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/slice-ansi/-/slice-ansi-0.0.4.tgz",
           "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
           "dev": true
         }
@@ -2989,13 +2989,13 @@
     },
     "cli-width": {
       "version": "2.2.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cli-width/-/cli-width-2.2.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/cli-width/-/cli-width-2.2.1.tgz",
       "integrity": "sha1-sEM9C06chH7xiGik7xb9X8gnHEg=",
       "dev": true
     },
     "clipboard": {
       "version": "2.0.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/clipboard/-/clipboard-2.0.6.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/clipboard/-/clipboard-2.0.6.tgz",
       "integrity": "sha1-UpISlu7A/fd+rRdJQhshyWhkc3Y=",
       "dev": true,
       "optional": true,
@@ -3007,7 +3007,7 @@
     },
     "cliui": {
       "version": "5.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cliui/-/cliui-5.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/cliui/-/cliui-5.0.0.tgz",
       "integrity": "sha1-3u/P2y6AB4SqNPRvoI4GhRx7u8U=",
       "dev": true,
       "requires": {
@@ -3018,25 +3018,25 @@
       "dependencies": {
         "ansi-regex": {
           "version": "4.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-4.1.0.tgz",
           "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc=",
           "dev": true
         },
         "emoji-regex": {
           "version": "7.0.3",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/emoji-regex/-/emoji-regex-7.0.3.tgz",
           "integrity": "sha1-kzoEBShgyF6DwSJHnEdIqOTHIVY=",
           "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
         "string-width": {
           "version": "3.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string-width/-/string-width-3.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/string-width/-/string-width-3.1.0.tgz",
           "integrity": "sha1-InZ74htirxCBV0MG9prFG2IgOWE=",
           "dev": true,
           "requires": {
@@ -3047,7 +3047,7 @@
         },
         "strip-ansi": {
           "version": "5.2.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
           "dev": true,
           "requires": {
@@ -3058,13 +3058,13 @@
     },
     "clone": {
       "version": "2.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/clone/-/clone-2.1.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/clone/-/clone-2.1.2.tgz",
       "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
       "dev": true
     },
     "clone-response": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/clone-response/-/clone-response-1.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/clone-response/-/clone-response-1.0.2.tgz",
       "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
       "dev": true,
       "requires": {
@@ -3073,19 +3073,19 @@
     },
     "clone-stats": {
       "version": "0.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/clone-stats/-/clone-stats-0.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/clone-stats/-/clone-stats-0.0.1.tgz",
       "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE=",
       "dev": true
     },
     "code-point-at": {
       "version": "1.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/code-point-at/-/code-point-at-1.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "dev": true
     },
     "collection-visit": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/collection-visit/-/collection-visit-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/collection-visit/-/collection-visit-1.0.0.tgz",
       "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
       "dev": true,
       "requires": {
@@ -3095,7 +3095,7 @@
     },
     "color": {
       "version": "3.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/color/-/color-3.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/color/-/color-3.0.0.tgz",
       "integrity": "sha1-2SC0Mo1TSjrIKV1o971LpsQnvpo=",
       "dev": true,
       "requires": {
@@ -3105,7 +3105,7 @@
     },
     "color-convert": {
       "version": "1.9.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/color-convert/-/color-convert-1.9.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha1-u3GFBpDh8TZWfeYp0tVHHe2kweg=",
       "dev": true,
       "requires": {
@@ -3114,13 +3114,13 @@
     },
     "color-name": {
       "version": "1.1.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/color-name/-/color-name-1.1.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
     "color-string": {
       "version": "1.5.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/color-string/-/color-string-1.5.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/color-string/-/color-string-1.5.3.tgz",
       "integrity": "sha1-ybvF8BtYtUkvPWhXRZy2WQziBMw=",
       "dev": true,
       "requires": {
@@ -3130,19 +3130,19 @@
     },
     "colornames": {
       "version": "1.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/colornames/-/colornames-1.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/colornames/-/colornames-1.1.1.tgz",
       "integrity": "sha1-+IiQMGhcfE/54qVZ9Qd+t2qBb5Y=",
       "dev": true
     },
     "colors": {
       "version": "1.4.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/colors/-/colors-1.4.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/colors/-/colors-1.4.0.tgz",
       "integrity": "sha1-xQSRR51MG9rtLJztMs98fcI2D3g=",
       "dev": true
     },
     "colorspace": {
       "version": "1.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/colorspace/-/colorspace-1.1.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/colorspace/-/colorspace-1.1.2.tgz",
       "integrity": "sha1-4BKJUNCCuGohaFgHlqCqXWxo2MU=",
       "dev": true,
       "requires": {
@@ -3152,7 +3152,7 @@
     },
     "combined-stream": {
       "version": "1.0.8",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/combined-stream/-/combined-stream-1.0.8.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha1-w9RaizT9cwYxoRCoolIGgrMdWn8=",
       "dev": true,
       "requires": {
@@ -3161,7 +3161,7 @@
     },
     "command-line-args": {
       "version": "5.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/command-line-args/-/command-line-args-5.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/command-line-args/-/command-line-args-5.1.1.tgz",
       "integrity": "sha1-iOeT5bs86zB1SoaGPwQBrJL9Npo=",
       "dev": true,
       "requires": {
@@ -3173,7 +3173,7 @@
     },
     "command-line-usage": {
       "version": "5.0.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/command-line-usage/-/command-line-usage-5.0.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/command-line-usage/-/command-line-usage-5.0.5.tgz",
       "integrity": "sha1-XyWTP/5t7dmDxjXTiiHX5iP9o1c=",
       "dev": true,
       "requires": {
@@ -3185,7 +3185,7 @@
       "dependencies": {
         "array-back": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/array-back/-/array-back-2.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/array-back/-/array-back-2.0.0.tgz",
           "integrity": "sha1-aHdHHVHsycm/phNvtsfV/ml0gCI=",
           "dev": true,
           "requires": {
@@ -3194,7 +3194,7 @@
         },
         "chalk": {
           "version": "2.4.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/chalk/-/chalk-2.4.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
           "dev": true,
           "requires": {
@@ -3205,7 +3205,7 @@
         },
         "typical": {
           "version": "2.6.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/typical/-/typical-2.6.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/typical/-/typical-2.6.1.tgz",
           "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0=",
           "dev": true
         }
@@ -3213,31 +3213,31 @@
     },
     "commander": {
       "version": "2.20.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/commander/-/commander-2.20.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/commander/-/commander-2.20.3.tgz",
       "integrity": "sha1-/UhehMA+tIgcIHIrpIA16FMa6zM=",
       "dev": true
     },
     "component-bind": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/component-bind/-/component-bind-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/component-bind/-/component-bind-1.0.0.tgz",
       "integrity": "sha1-AMYIq33Nk4l8AAllGx06jh5zu9E=",
       "dev": true
     },
     "component-emitter": {
       "version": "1.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/component-emitter/-/component-emitter-1.3.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/component-emitter/-/component-emitter-1.3.0.tgz",
       "integrity": "sha1-FuQHD7qK4ptnnyIVhT7hgasuq8A=",
       "dev": true
     },
     "component-inherit": {
       "version": "0.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/component-inherit/-/component-inherit-0.0.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/component-inherit/-/component-inherit-0.0.3.tgz",
       "integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM=",
       "dev": true
     },
     "compress-commons": {
       "version": "2.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/compress-commons/-/compress-commons-2.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/compress-commons/-/compress-commons-2.1.1.tgz",
       "integrity": "sha1-lBDZpTTPhDXj+7t8bOSN4twvBhA=",
       "dev": true,
       "requires": {
@@ -3249,7 +3249,7 @@
     },
     "compressible": {
       "version": "2.0.18",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/compressible/-/compressible-2.0.18.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/compressible/-/compressible-2.0.18.tgz",
       "integrity": "sha1-r1PMprBw1MPAdQ+9dyhqbXzEb7o=",
       "dev": true,
       "requires": {
@@ -3258,7 +3258,7 @@
     },
     "compression": {
       "version": "1.7.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/compression/-/compression-1.7.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/compression/-/compression-1.7.4.tgz",
       "integrity": "sha1-lVI+/xcMpXwpoMpB5v4TH0Hlu48=",
       "dev": true,
       "requires": {
@@ -3273,13 +3273,13 @@
       "dependencies": {
         "bytes": {
           "version": "3.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/bytes/-/bytes-3.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/bytes/-/bytes-3.0.0.tgz",
           "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
           "dev": true
         },
         "debug": {
           "version": "2.6.9",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-2.6.9.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/debug/-/debug-2.6.9.tgz",
           "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
           "dev": true,
           "requires": {
@@ -3290,13 +3290,13 @@
     },
     "concat-map": {
       "version": "0.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/concat-map/-/concat-map-0.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
     "concat-stream": {
       "version": "1.6.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/concat-stream/-/concat-stream-1.6.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/concat-stream/-/concat-stream-1.6.2.tgz",
       "integrity": "sha1-kEvfGUzTEi/Gdcd/xKw9T/D9GjQ=",
       "dev": true,
       "requires": {
@@ -3308,7 +3308,7 @@
     },
     "configstore": {
       "version": "5.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/configstore/-/configstore-5.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/configstore/-/configstore-5.0.1.tgz",
       "integrity": "sha1-02UCG130uYzdGH1qOw4/anzF7ZY=",
       "dev": true,
       "requires": {
@@ -3322,13 +3322,13 @@
     },
     "console-control-strings": {
       "version": "1.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
       "dev": true
     },
     "content-disposition": {
       "version": "0.5.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/content-disposition/-/content-disposition-0.5.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/content-disposition/-/content-disposition-0.5.3.tgz",
       "integrity": "sha1-4TDK9+cnkIfFYWwgB9BIVpiYT70=",
       "dev": true,
       "requires": {
@@ -3337,13 +3337,13 @@
     },
     "content-type": {
       "version": "1.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/content-type/-/content-type-1.0.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/content-type/-/content-type-1.0.4.tgz",
       "integrity": "sha1-4TjMdeBAxyexlm/l5fjJruJW/js=",
       "dev": true
     },
     "convert-source-map": {
       "version": "1.7.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/convert-source-map/-/convert-source-map-1.7.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/convert-source-map/-/convert-source-map-1.7.0.tgz",
       "integrity": "sha1-F6LLiC1/d9NJBYXizmxSRCSjpEI=",
       "dev": true,
       "requires": {
@@ -3352,37 +3352,37 @@
     },
     "cookie": {
       "version": "0.4.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cookie/-/cookie-0.4.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/cookie/-/cookie-0.4.0.tgz",
       "integrity": "sha1-vrQ35wIrO21JAZ0IhmUwPr6cFLo=",
       "dev": true
     },
     "cookie-signature": {
       "version": "1.0.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
       "dev": true
     },
     "copy-descriptor": {
       "version": "0.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
       "dev": true
     },
     "core-js": {
       "version": "3.6.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/core-js/-/core-js-3.6.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/core-js/-/core-js-3.6.5.tgz",
       "integrity": "sha1-c5XcJzrzf7LlDpvT2f6EEoUjHRo=",
       "dev": true
     },
     "core-util-is": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/core-util-is/-/core-util-is-1.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
     "cors": {
       "version": "2.8.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cors/-/cors-2.8.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/cors/-/cors-2.8.5.tgz",
       "integrity": "sha1-6sEdpRWS3Ya58G9uesKTs9+HXSk=",
       "dev": true,
       "requires": {
@@ -3392,13 +3392,13 @@
     },
     "corser": {
       "version": "2.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/corser/-/corser-2.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/corser/-/corser-2.0.1.tgz",
       "integrity": "sha1-jtolLsqrWEDc2XXOuQ2TcMgZ/4c=",
       "dev": true
     },
     "cosmiconfig": {
       "version": "6.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
       "integrity": "sha1-2k/uhTxS9rHmk19BwaL8UL1KmYI=",
       "dev": true,
       "requires": {
@@ -3411,7 +3411,7 @@
       "dependencies": {
         "parse-json": {
           "version": "5.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/parse-json/-/parse-json-5.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/parse-json/-/parse-json-5.0.0.tgz",
           "integrity": "sha1-c+URTJhtFD76NxLU6iTbmkJm9g8=",
           "dev": true,
           "requires": {
@@ -3425,7 +3425,7 @@
     },
     "crc": {
       "version": "3.8.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/crc/-/crc-3.8.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/crc/-/crc-3.8.0.tgz",
       "integrity": "sha1-rWAmnCyFb4wpnixMwN5FVpFAVsY=",
       "dev": true,
       "requires": {
@@ -3434,7 +3434,7 @@
     },
     "crc32-stream": {
       "version": "3.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/crc32-stream/-/crc32-stream-3.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/crc32-stream/-/crc32-stream-3.0.1.tgz",
       "integrity": "sha1-yubu7QA7DkTXOdJ53lrmOxcbToU=",
       "dev": true,
       "requires": {
@@ -3444,7 +3444,7 @@
       "dependencies": {
         "readable-stream": {
           "version": "3.6.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/readable-stream/-/readable-stream-3.6.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/readable-stream/-/readable-stream-3.6.0.tgz",
           "integrity": "sha1-M3u9o63AcGvT4CRCaihtS0sskZg=",
           "dev": true,
           "requires": {
@@ -3455,13 +3455,13 @@
         },
         "safe-buffer": {
           "version": "5.2.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/safe-buffer/-/safe-buffer-5.2.1.tgz",
           "integrity": "sha1-Hq+fqb2x/dTsdfWPnNtOa3gn7sY=",
           "dev": true
         },
         "string_decoder": {
           "version": "1.3.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string_decoder/-/string_decoder-1.3.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/string_decoder/-/string_decoder-1.3.0.tgz",
           "integrity": "sha1-QvEUWUpGzxqOMLCoT1bHjD7awh4=",
           "dev": true,
           "requires": {
@@ -3472,7 +3472,7 @@
     },
     "create-error-class": {
       "version": "3.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/create-error-class/-/create-error-class-3.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/create-error-class/-/create-error-class-3.0.2.tgz",
       "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
       "dev": true,
       "requires": {
@@ -3481,7 +3481,7 @@
     },
     "cross-spawn": {
       "version": "7.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/cross-spawn/-/cross-spawn-7.0.3.tgz",
       "integrity": "sha1-9zqFudXUHQRVUcF34ogtSshXKKY=",
       "dev": true,
       "requires": {
@@ -3492,7 +3492,7 @@
       "dependencies": {
         "which": {
           "version": "2.0.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/which/-/which-2.0.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/which/-/which-2.0.2.tgz",
           "integrity": "sha1-fGqN0KY2oDJ+ELWckobu6T8/UbE=",
           "dev": true,
           "requires": {
@@ -3503,25 +3503,25 @@
     },
     "crypt": {
       "version": "0.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/crypt/-/crypt-0.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/crypt/-/crypt-0.0.2.tgz",
       "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=",
       "dev": true
     },
     "crypto-random-string": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
       "integrity": "sha1-7yp6lm7BEIM4g2m6oC6+rSKbMNU=",
       "dev": true
     },
     "css-b64-images": {
       "version": "0.2.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/css-b64-images/-/css-b64-images-0.2.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/css-b64-images/-/css-b64-images-0.2.5.tgz",
       "integrity": "sha1-QgBdgyBLK0pdk7axpWRBM7WSegI=",
       "dev": true
     },
     "css-slam": {
       "version": "2.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/css-slam/-/css-slam-2.1.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/css-slam/-/css-slam-2.1.2.tgz",
       "integrity": "sha1-PTWxkiyz4AAqRciasYlJJQjEk+U=",
       "dev": true,
       "requires": {
@@ -3534,7 +3534,7 @@
       "dependencies": {
         "parse5": {
           "version": "4.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/parse5/-/parse5-4.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/parse5/-/parse5-4.0.0.tgz",
           "integrity": "sha1-bXhlbj2o14tOwLkG98CO8d/j9gg=",
           "dev": true
         }
@@ -3542,25 +3542,25 @@
     },
     "css-vars-ponyfill": {
       "version": "1.17.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/css-vars-ponyfill/-/css-vars-ponyfill-1.17.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/css-vars-ponyfill/-/css-vars-ponyfill-1.17.2.tgz",
       "integrity": "sha1-GOx7wv0Ybr+vme42eyYortQ4ids=",
       "dev": true
     },
     "cssbeautify": {
       "version": "0.3.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cssbeautify/-/cssbeautify-0.3.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/cssbeautify/-/cssbeautify-0.3.1.tgz",
       "integrity": "sha1-Et0fc0A1wub6ymfcvc73TkKBE5c=",
       "dev": true
     },
     "cssom": {
       "version": "0.4.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cssom/-/cssom-0.4.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/cssom/-/cssom-0.4.4.tgz",
       "integrity": "sha1-WmbPk9LQtmHYC/akT7ZfXC5OChA=",
       "dev": true
     },
     "cssstyle": {
       "version": "2.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cssstyle/-/cssstyle-2.3.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/cssstyle/-/cssstyle-2.3.0.tgz",
       "integrity": "sha1-/2ZaDdvcMYZLCWR/NBY0Q9kLCFI=",
       "dev": true,
       "requires": {
@@ -3569,7 +3569,7 @@
       "dependencies": {
         "cssom": {
           "version": "0.3.8",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cssom/-/cssom-0.3.8.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/cssom/-/cssom-0.3.8.tgz",
           "integrity": "sha1-nxJ29bK0Y/IRTT8sdSUK+MGjb0o=",
           "dev": true
         }
@@ -3577,13 +3577,13 @@
     },
     "cubic2quad": {
       "version": "1.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cubic2quad/-/cubic2quad-1.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/cubic2quad/-/cubic2quad-1.1.1.tgz",
       "integrity": "sha1-abGcYaP1tB7PLx1fro+wNBWqixU=",
       "dev": true
     },
     "currently-unhandled": {
       "version": "0.4.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
       "dev": true,
       "requires": {
@@ -3592,7 +3592,7 @@
     },
     "dashdash": {
       "version": "1.14.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/dashdash/-/dashdash-1.14.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
       "requires": {
@@ -3601,7 +3601,7 @@
     },
     "data-urls": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/data-urls/-/data-urls-2.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/data-urls/-/data-urls-2.0.0.tgz",
       "integrity": "sha1-FWSFpyljqXD11YIar2Qr7yvy25s=",
       "dev": true,
       "requires": {
@@ -3612,7 +3612,7 @@
       "dependencies": {
         "tr46": {
           "version": "2.0.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/tr46/-/tr46-2.0.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/tr46/-/tr46-2.0.2.tgz",
           "integrity": "sha1-Ayc1ht7xWVrgj+2zjXczzukdJHk=",
           "dev": true,
           "requires": {
@@ -3621,13 +3621,13 @@
         },
         "webidl-conversions": {
           "version": "5.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
           "integrity": "sha1-rlnIoAsSFUOirMZcBDT1ew/BGv8=",
           "dev": true
         },
         "whatwg-url": {
           "version": "8.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/whatwg-url/-/whatwg-url-8.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/whatwg-url/-/whatwg-url-8.1.0.tgz",
           "integrity": "sha1-xiis3PRbgidM5yge4x3TyDl5F3E=",
           "dev": true,
           "requires": {
@@ -3640,13 +3640,13 @@
     },
     "date-fns": {
       "version": "1.30.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/date-fns/-/date-fns-1.30.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/date-fns/-/date-fns-1.30.1.tgz",
       "integrity": "sha1-LnG/CxGRU9u0zE6I2epaz7UNwFw=",
       "dev": true
     },
     "debug": {
       "version": "3.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-3.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/debug/-/debug-3.1.0.tgz",
       "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
       "dev": true,
       "requires": {
@@ -3655,13 +3655,13 @@
     },
     "decamelize": {
       "version": "1.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/decamelize/-/decamelize-1.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true
     },
     "decamelize-keys": {
       "version": "1.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
       "integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
       "dev": true,
       "requires": {
@@ -3671,7 +3671,7 @@
       "dependencies": {
         "map-obj": {
           "version": "1.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/map-obj/-/map-obj-1.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/map-obj/-/map-obj-1.0.1.tgz",
           "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
           "dev": true
         }
@@ -3679,19 +3679,19 @@
     },
     "decimal.js": {
       "version": "10.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/decimal.js/-/decimal.js-10.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/decimal.js/-/decimal.js-10.2.0.tgz",
       "integrity": "sha1-OUZhE6ngNhEdAvgkibX9awte0jE=",
       "dev": true
     },
     "decode-uri-component": {
       "version": "0.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
       "dev": true
     },
     "decompress-response": {
       "version": "3.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/decompress-response/-/decompress-response-3.3.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/decompress-response/-/decompress-response-3.3.0.tgz",
       "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
       "dev": true,
       "requires": {
@@ -3700,7 +3700,7 @@
     },
     "deep-eql": {
       "version": "3.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/deep-eql/-/deep-eql-3.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/deep-eql/-/deep-eql-3.0.1.tgz",
       "integrity": "sha1-38lARACtHI/gI+faHfHBR8S0RN8=",
       "dev": true,
       "requires": {
@@ -3709,25 +3709,25 @@
     },
     "deep-extend": {
       "version": "0.6.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/deep-extend/-/deep-extend-0.6.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/deep-extend/-/deep-extend-0.6.0.tgz",
       "integrity": "sha1-xPp8lUBKF6nD6Mp+FTcxK3NjMKw=",
       "dev": true
     },
     "deep-is": {
       "version": "0.1.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/deep-is/-/deep-is-0.1.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
     },
     "defer-to-connect": {
       "version": "1.1.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
       "integrity": "sha1-MxrgUMCNz3ifjIOnuB8O2U9KxZE=",
       "dev": true
     },
     "define-properties": {
       "version": "1.1.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/define-properties/-/define-properties-1.1.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/define-properties/-/define-properties-1.1.3.tgz",
       "integrity": "sha1-z4jabL7ib+bbcJT2HYcMvYTO6fE=",
       "dev": true,
       "requires": {
@@ -3736,7 +3736,7 @@
     },
     "define-property": {
       "version": "2.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/define-property/-/define-property-2.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/define-property/-/define-property-2.0.2.tgz",
       "integrity": "sha1-1Flono1lS6d+AqgX+HENcCyxbp0=",
       "dev": true,
       "requires": {
@@ -3746,7 +3746,7 @@
       "dependencies": {
         "is-accessor-descriptor": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
           "dev": true,
           "requires": {
@@ -3755,7 +3755,7 @@
         },
         "is-data-descriptor": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
           "dev": true,
           "requires": {
@@ -3764,7 +3764,7 @@
         },
         "is-descriptor": {
           "version": "1.0.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
           "dev": true,
           "requires": {
@@ -3777,7 +3777,7 @@
     },
     "del": {
       "version": "5.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/del/-/del-5.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/del/-/del-5.1.0.tgz",
       "integrity": "sha1-2Uh8lONnQQ5u/ykl7ljAyEp1s6c=",
       "dev": true,
       "requires": {
@@ -3793,7 +3793,7 @@
       "dependencies": {
         "rimraf": {
           "version": "3.0.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/rimraf/-/rimraf-3.0.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/rimraf/-/rimraf-3.0.2.tgz",
           "integrity": "sha1-8aVAK6YiCtUswSgrrBrjqkn9Bho=",
           "dev": true,
           "requires": {
@@ -3804,44 +3804,44 @@
     },
     "delayed-stream": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
     },
     "delegate": {
       "version": "3.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/delegate/-/delegate-3.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/delegate/-/delegate-3.2.0.tgz",
       "integrity": "sha1-tmtxwxWFIuirV0T3INjKDCr1kWY=",
       "dev": true,
       "optional": true
     },
     "delegates": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/delegates/-/delegates-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/delegates/-/delegates-1.0.0.tgz",
       "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
       "dev": true
     },
     "depd": {
       "version": "1.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/depd/-/depd-1.1.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/depd/-/depd-1.1.2.tgz",
       "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
       "dev": true
     },
     "destroy": {
       "version": "1.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/destroy/-/destroy-1.0.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
       "dev": true
     },
     "detect-file": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/detect-file/-/detect-file-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/detect-file/-/detect-file-1.0.0.tgz",
       "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=",
       "dev": true
     },
     "detect-indent": {
       "version": "4.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/detect-indent/-/detect-indent-4.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/detect-indent/-/detect-indent-4.0.0.tgz",
       "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
       "dev": true,
       "requires": {
@@ -3850,13 +3850,13 @@
     },
     "detect-node": {
       "version": "2.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/detect-node/-/detect-node-2.0.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/detect-node/-/detect-node-2.0.4.tgz",
       "integrity": "sha1-AU7o+PZpxcWAI9pkuBecCDooxGw=",
       "dev": true
     },
     "diagnostics": {
       "version": "1.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/diagnostics/-/diagnostics-1.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/diagnostics/-/diagnostics-1.1.1.tgz",
       "integrity": "sha1-yrasM99wydmnJ0kK5DrJladpsio=",
       "dev": true,
       "requires": {
@@ -3867,7 +3867,7 @@
     },
     "dicer": {
       "version": "0.2.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/dicer/-/dicer-0.2.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/dicer/-/dicer-0.2.5.tgz",
       "integrity": "sha1-WZbAhrszIYyBLAkL3cCc0S+stw8=",
       "dev": true,
       "requires": {
@@ -3877,7 +3877,7 @@
       "dependencies": {
         "readable-stream": {
           "version": "1.1.14",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/readable-stream/-/readable-stream-1.1.14.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
@@ -3891,13 +3891,13 @@
     },
     "diff": {
       "version": "3.5.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/diff/-/diff-3.5.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/diff/-/diff-3.5.0.tgz",
       "integrity": "sha1-gAwN0eCov7yVg1wgKtIg/jF+WhI=",
       "dev": true
     },
     "dir-glob": {
       "version": "3.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/dir-glob/-/dir-glob-3.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/dir-glob/-/dir-glob-3.0.1.tgz",
       "integrity": "sha1-Vtv3PZkqSpO6FYT0U0Bj/S5BcX8=",
       "dev": true,
       "requires": {
@@ -3906,7 +3906,7 @@
     },
     "doctrine": {
       "version": "3.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/doctrine/-/doctrine-3.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/doctrine/-/doctrine-3.0.0.tgz",
       "integrity": "sha1-rd6+rXKmV023g2OdyHoSF3OXOWE=",
       "dev": true,
       "requires": {
@@ -3915,7 +3915,7 @@
     },
     "document-register-element": {
       "version": "1.14.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/document-register-element/-/document-register-element-1.14.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/document-register-element/-/document-register-element-1.14.3.tgz",
       "integrity": "sha1-MzXUV432oVNqNFlbkcyjbdXbYdc=",
       "requires": {
         "lightercollective": "^0.3.0"
@@ -3923,7 +3923,7 @@
     },
     "dom-serializer": {
       "version": "0.2.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/dom-serializer/-/dom-serializer-0.2.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/dom-serializer/-/dom-serializer-0.2.2.tgz",
       "integrity": "sha1-GvuB9TNxcXXUeGVd68XjMtn5u1E=",
       "dev": true,
       "requires": {
@@ -3933,7 +3933,7 @@
     },
     "dom-urls": {
       "version": "1.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/dom-urls/-/dom-urls-1.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/dom-urls/-/dom-urls-1.1.0.tgz",
       "integrity": "sha1-AB3fgWKM0ecGElxxdvU8zsVdkY4=",
       "dev": true,
       "requires": {
@@ -3942,7 +3942,7 @@
     },
     "dom5": {
       "version": "3.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/dom5/-/dom5-3.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/dom5/-/dom5-3.0.1.tgz",
       "integrity": "sha1-zfxzMfN24oS/N55uoFSvwTZwKUQ=",
       "dev": true,
       "requires": {
@@ -3953,7 +3953,7 @@
       "dependencies": {
         "parse5": {
           "version": "4.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/parse5/-/parse5-4.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/parse5/-/parse5-4.0.0.tgz",
           "integrity": "sha1-bXhlbj2o14tOwLkG98CO8d/j9gg=",
           "dev": true
         }
@@ -3961,13 +3961,13 @@
     },
     "domelementtype": {
       "version": "2.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/domelementtype/-/domelementtype-2.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/domelementtype/-/domelementtype-2.0.1.tgz",
       "integrity": "sha1-H4vf6R9aeAYydOgDtL3O326U+U0=",
       "dev": true
     },
     "domexception": {
       "version": "2.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/domexception/-/domexception-2.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/domexception/-/domexception-2.0.1.tgz",
       "integrity": "sha1-+0Su+6eT4VdLCvau0oAdBXUp8wQ=",
       "dev": true,
       "requires": {
@@ -3976,7 +3976,7 @@
       "dependencies": {
         "webidl-conversions": {
           "version": "5.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
           "integrity": "sha1-rlnIoAsSFUOirMZcBDT1ew/BGv8=",
           "dev": true
         }
@@ -3984,7 +3984,7 @@
     },
     "domhandler": {
       "version": "3.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/domhandler/-/domhandler-3.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/domhandler/-/domhandler-3.0.0.tgz",
       "integrity": "sha1-Uc0T78ox2pW7sMW+46SDAOMzs+k=",
       "dev": true,
       "requires": {
@@ -3993,7 +3993,7 @@
     },
     "domutils": {
       "version": "2.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/domutils/-/domutils-2.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/domutils/-/domutils-2.1.0.tgz",
       "integrity": "sha1-et4yAa9DcD/eFUlS46ho60tjXxY=",
       "dev": true,
       "requires": {
@@ -4004,7 +4004,7 @@
     },
     "dot-prop": {
       "version": "5.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/dot-prop/-/dot-prop-5.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/dot-prop/-/dot-prop-5.2.0.tgz",
       "integrity": "sha1-w07MKVVtxF8fTCJpe29JBODMT8s=",
       "dev": true,
       "requires": {
@@ -4013,13 +4013,13 @@
     },
     "duplexer": {
       "version": "0.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/duplexer/-/duplexer-0.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/duplexer/-/duplexer-0.1.1.tgz",
       "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
       "dev": true
     },
     "duplexer2": {
       "version": "0.1.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/duplexer2/-/duplexer2-0.1.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/duplexer2/-/duplexer2-0.1.4.tgz",
       "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
       "dev": true,
       "requires": {
@@ -4028,13 +4028,13 @@
     },
     "duplexer3": {
       "version": "0.1.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/duplexer3/-/duplexer3-0.1.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/duplexer3/-/duplexer3-0.1.4.tgz",
       "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
       "dev": true
     },
     "duplexify": {
       "version": "3.7.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/duplexify/-/duplexify-3.7.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/duplexify/-/duplexify-3.7.1.tgz",
       "integrity": "sha1-Kk31MX9sz9kfhtb9JdjYoQO4gwk=",
       "dev": true,
       "requires": {
@@ -4046,7 +4046,7 @@
     },
     "ecc-jsbn": {
       "version": "0.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
       "dev": true,
       "requires": {
@@ -4056,7 +4056,7 @@
     },
     "ecstatic": {
       "version": "3.3.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ecstatic/-/ecstatic-3.3.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ecstatic/-/ecstatic-3.3.2.tgz",
       "integrity": "sha1-bR3UmBTQBZRoLGUq22YHamnUbEg=",
       "dev": true,
       "requires": {
@@ -4068,7 +4068,7 @@
       "dependencies": {
         "url-join": {
           "version": "2.0.5",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/url-join/-/url-join-2.0.5.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/url-join/-/url-join-2.0.5.tgz",
           "integrity": "sha1-WvIvGMBSoACkjXuCxenC4v7tpyg=",
           "dev": true
         }
@@ -4076,31 +4076,31 @@
     },
     "ee-first": {
       "version": "1.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ee-first/-/ee-first-1.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
       "dev": true
     },
     "elegant-spinner": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
       "integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=",
       "dev": true
     },
     "emitter-component": {
       "version": "1.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/emitter-component/-/emitter-component-1.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/emitter-component/-/emitter-component-1.1.1.tgz",
       "integrity": "sha1-Bl4tvtaVm/RwZ57avq95gdEAOrY=",
       "dev": true
     },
     "emoji-regex": {
       "version": "8.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc=",
       "dev": true
     },
     "enabled": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/enabled/-/enabled-1.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/enabled/-/enabled-1.0.2.tgz",
       "integrity": "sha1-ll9lE9LC0cX0ZStkouM5ZGf8L5M=",
       "dev": true,
       "requires": {
@@ -4109,13 +4109,13 @@
     },
     "encodeurl": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/encodeurl/-/encodeurl-1.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
       "dev": true
     },
     "end-of-stream": {
       "version": "1.4.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/end-of-stream/-/end-of-stream-1.4.4.tgz",
       "integrity": "sha1-WuZKX0UFe682JuwU2gyl5LJDHrA=",
       "dev": true,
       "requires": {
@@ -4206,7 +4206,7 @@
     },
     "engine.io-parser": {
       "version": "2.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/engine.io-parser/-/engine.io-parser-2.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/engine.io-parser/-/engine.io-parser-2.2.0.tgz",
       "integrity": "sha1-MSxIlPV9UqArQgho2ntcHISvgO0=",
       "dev": true,
       "requires": {
@@ -4219,19 +4219,19 @@
     },
     "entities": {
       "version": "2.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/entities/-/entities-2.0.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/entities/-/entities-2.0.3.tgz",
       "integrity": "sha1-XEh+V0Krk8Fau12iJ1m4WQ7AO38=",
       "dev": true
     },
     "env-variable": {
       "version": "0.0.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/env-variable/-/env-variable-0.0.6.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/env-variable/-/env-variable-0.0.6.tgz",
       "integrity": "sha1-dKsgs3hsVFtitKSBOrjPInJsmAg=",
       "dev": true
     },
     "error-ex": {
       "version": "1.3.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/error-ex/-/error-ex-1.3.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/error-ex/-/error-ex-1.3.2.tgz",
       "integrity": "sha1-tKxAZIEH/c3PriQvQovqihTU8b8=",
       "dev": true,
       "requires": {
@@ -4240,7 +4240,7 @@
     },
     "es-abstract": {
       "version": "1.17.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/es-abstract/-/es-abstract-1.17.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/es-abstract/-/es-abstract-1.17.5.tgz",
       "integrity": "sha1-2MnR1myJgfuSAOIlHXme7pJ3Suk=",
       "dev": true,
       "requires": {
@@ -4259,7 +4259,7 @@
     },
     "es-to-primitive": {
       "version": "1.2.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
       "integrity": "sha1-5VzUyc3BiLzvsDs2bHNjI/xciYo=",
       "dev": true,
       "requires": {
@@ -4270,13 +4270,13 @@
     },
     "es6-promise": {
       "version": "4.2.8",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/es6-promise/-/es6-promise-4.2.8.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/es6-promise/-/es6-promise-4.2.8.tgz",
       "integrity": "sha1-TrIVlMlyvEBVPSduUQU5FD21Pgo=",
       "dev": true
     },
     "es6-promisify": {
       "version": "5.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/es6-promisify/-/es6-promisify-5.0.0.tgz",
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
       "dev": true,
       "requires": {
@@ -4285,25 +4285,25 @@
     },
     "escape-goat": {
       "version": "3.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/escape-goat/-/escape-goat-3.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/escape-goat/-/escape-goat-3.0.0.tgz",
       "integrity": "sha1-6LX7ZYVT/oo8SVnDFsbruMhCsZw=",
       "dev": true
     },
     "escape-html": {
       "version": "1.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/escape-html/-/escape-html-1.0.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
       "dev": true
     },
     "escape-string-regexp": {
       "version": "1.0.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
     "escodegen": {
       "version": "1.14.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/escodegen/-/escodegen-1.14.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/escodegen/-/escodegen-1.14.2.tgz",
       "integrity": "sha1-FKtxv1AmwqoIFzr7oixvMXMoSoQ=",
       "dev": true,
       "requires": {
@@ -4316,7 +4316,7 @@
       "dependencies": {
         "levn": {
           "version": "0.3.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/levn/-/levn-0.3.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/levn/-/levn-0.3.0.tgz",
           "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
           "dev": true,
           "requires": {
@@ -4326,7 +4326,7 @@
         },
         "optionator": {
           "version": "0.8.3",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/optionator/-/optionator-0.8.3.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/optionator/-/optionator-0.8.3.tgz",
           "integrity": "sha1-hPodA2/p08fiHZmIS2ARZ+yPtJU=",
           "dev": true,
           "requires": {
@@ -4340,13 +4340,13 @@
         },
         "prelude-ls": {
           "version": "1.1.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/prelude-ls/-/prelude-ls-1.1.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/prelude-ls/-/prelude-ls-1.1.2.tgz",
           "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
           "dev": true
         },
         "type-check": {
           "version": "0.3.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/type-check/-/type-check-0.3.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/type-check/-/type-check-0.3.2.tgz",
           "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
           "dev": true,
           "requires": {
@@ -4445,13 +4445,13 @@
     },
     "eslint-config-google": {
       "version": "0.14.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/eslint-config-google/-/eslint-config-google-0.14.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/eslint-config-google/-/eslint-config-google-0.14.0.tgz",
       "integrity": "sha1-T1+HWbpuEbQkKUohnb+hjFCLzBo=",
       "dev": true
     },
     "eslint-plugin-html": {
       "version": "6.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/eslint-plugin-html/-/eslint-plugin-html-6.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/eslint-plugin-html/-/eslint-plugin-html-6.0.2.tgz",
       "integrity": "sha1-/L0pPiGNA91ywUf8mZ0YXG9Zif4=",
       "dev": true,
       "requires": {
@@ -4460,7 +4460,7 @@
     },
     "eslint-plugin-only-warn": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/eslint-plugin-only-warn/-/eslint-plugin-only-warn-1.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/eslint-plugin-only-warn/-/eslint-plugin-only-warn-1.0.2.tgz",
       "integrity": "sha1-Ir886fCoZx7s94dX1u/z/VGL4Ko=",
       "dev": true
     },
@@ -4476,7 +4476,7 @@
     },
     "eslint-utils": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/eslint-utils/-/eslint-utils-2.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/eslint-utils/-/eslint-utils-2.0.0.tgz",
       "integrity": "sha1-e+HMcPJ6cqds0UqmmLyr7WiQ4c0=",
       "dev": true,
       "requires": {
@@ -4502,13 +4502,13 @@
     },
     "esprima": {
       "version": "4.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/esprima/-/esprima-4.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha1-E7BM2z5sXRnfkatph6hpVhmwqnE=",
       "dev": true
     },
     "esquery": {
       "version": "1.3.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/esquery/-/esquery-1.3.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/esquery/-/esquery-1.3.1.tgz",
       "integrity": "sha1-t4tYKKqOIU4p+3TE1bdS4cAz2lc=",
       "dev": true,
       "requires": {
@@ -4517,7 +4517,7 @@
       "dependencies": {
         "estraverse": {
           "version": "5.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/estraverse/-/estraverse-5.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/estraverse/-/estraverse-5.1.0.tgz",
           "integrity": "sha1-N0MJ05/ZNa5QDnuS6Ka0xyDllkI=",
           "dev": true
         }
@@ -4525,7 +4525,7 @@
     },
     "esrecurse": {
       "version": "4.2.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/esrecurse/-/esrecurse-4.2.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/esrecurse/-/esrecurse-4.2.1.tgz",
       "integrity": "sha1-AHo7n9vCs7uH5IeeoZyS/b05Qs8=",
       "dev": true,
       "requires": {
@@ -4534,25 +4534,25 @@
     },
     "estraverse": {
       "version": "4.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/estraverse/-/estraverse-4.3.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/estraverse/-/estraverse-4.3.0.tgz",
       "integrity": "sha1-OYrT88WiSUi+dyXoPRGn3ijNvR0=",
       "dev": true
     },
     "esutils": {
       "version": "2.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/esutils/-/esutils-2.0.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha1-dNLrTeC42hKTcRkQ1Qd1ubcQ72Q=",
       "dev": true
     },
     "etag": {
       "version": "1.8.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/etag/-/etag-1.8.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
       "dev": true
     },
     "event-stream": {
       "version": "4.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/event-stream/-/event-stream-4.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/event-stream/-/event-stream-4.0.1.tgz",
       "integrity": "sha1-QJKAjsmV0N116kWAwd9qdNss3mU=",
       "dev": true,
       "requires": {
@@ -4567,13 +4567,13 @@
     },
     "eventemitter3": {
       "version": "4.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/eventemitter3/-/eventemitter3-4.0.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/eventemitter3/-/eventemitter3-4.0.4.tgz",
       "integrity": "sha1-tUY6zmNaCD0Bi9x8kXtMXxCoU4Q=",
       "dev": true
     },
     "execa": {
       "version": "4.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/execa/-/execa-4.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/execa/-/execa-4.0.2.tgz",
       "integrity": "sha1-rYf7ey2dVk9w0rYtURvuQdXLskA=",
       "dev": true,
       "requires": {
@@ -4590,7 +4590,7 @@
       "dependencies": {
         "is-stream": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-stream/-/is-stream-2.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-stream/-/is-stream-2.0.0.tgz",
           "integrity": "sha1-venDJoDW+uBBKdasnZIc54FfeOM=",
           "dev": true
         }
@@ -4598,7 +4598,7 @@
     },
     "expand-brackets": {
       "version": "2.1.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/expand-brackets/-/expand-brackets-2.1.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/expand-brackets/-/expand-brackets-2.1.4.tgz",
       "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
       "dev": true,
       "requires": {
@@ -4613,7 +4613,7 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-2.6.9.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/debug/-/debug-2.6.9.tgz",
           "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
           "dev": true,
           "requires": {
@@ -4622,7 +4622,7 @@
         },
         "define-property": {
           "version": "0.2.5",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/define-property/-/define-property-0.2.5.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
@@ -4631,7 +4631,7 @@
         },
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
@@ -4642,7 +4642,7 @@
     },
     "expand-range": {
       "version": "1.8.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/expand-range/-/expand-range-1.8.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/expand-range/-/expand-range-1.8.2.tgz",
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "dev": true,
       "requires": {
@@ -4651,7 +4651,7 @@
       "dependencies": {
         "fill-range": {
           "version": "2.2.4",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/fill-range/-/fill-range-2.2.4.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/fill-range/-/fill-range-2.2.4.tgz",
           "integrity": "sha1-6x53OrsFbc2N8r/favWbizqTZWU=",
           "dev": true,
           "requires": {
@@ -4664,13 +4664,13 @@
         },
         "is-buffer": {
           "version": "1.1.6",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-buffer/-/is-buffer-1.1.6.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-buffer/-/is-buffer-1.1.6.tgz",
           "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
           "dev": true
         },
         "is-number": {
           "version": "2.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-number/-/is-number-2.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-number/-/is-number-2.1.0.tgz",
           "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
           "dev": true,
           "requires": {
@@ -4679,13 +4679,13 @@
         },
         "isarray": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/isarray/-/isarray-1.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true
         },
         "isobject": {
           "version": "2.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/isobject/-/isobject-2.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/isobject/-/isobject-2.1.0.tgz",
           "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
           "dev": true,
           "requires": {
@@ -4694,7 +4694,7 @@
         },
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
@@ -4705,7 +4705,7 @@
     },
     "expand-tilde": {
       "version": "2.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/expand-tilde/-/expand-tilde-2.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/expand-tilde/-/expand-tilde-2.0.2.tgz",
       "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
       "dev": true,
       "requires": {
@@ -4714,7 +4714,7 @@
     },
     "express": {
       "version": "4.17.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/express/-/express-4.17.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/express/-/express-4.17.1.tgz",
       "integrity": "sha1-RJH8OGBc9R+GKdOcK10Cb5ikwTQ=",
       "dev": true,
       "requires": {
@@ -4752,7 +4752,7 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-2.6.9.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/debug/-/debug-2.6.9.tgz",
           "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
           "dev": true,
           "requires": {
@@ -4761,19 +4761,19 @@
         },
         "path-to-regexp": {
           "version": "0.1.7",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
           "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
           "dev": true
         },
         "qs": {
           "version": "6.7.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/qs/-/qs-6.7.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/qs/-/qs-6.7.0.tgz",
           "integrity": "sha1-QdwaAV49WB8WIXdr4xr7KHapsbw=",
           "dev": true
         },
         "send": {
           "version": "0.17.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/send/-/send-0.17.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/send/-/send-0.17.1.tgz",
           "integrity": "sha1-wdiwWfeQD3Rm3Uk4vcROEd2zdsg=",
           "dev": true,
           "requires": {
@@ -4794,7 +4794,7 @@
           "dependencies": {
             "ms": {
               "version": "2.1.1",
-              "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.1.1.tgz",
+              "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ms/-/ms-2.1.1.tgz",
               "integrity": "sha1-MKWGTrPrsKZvLr5tcnrwagnYbgo=",
               "dev": true
             }
@@ -4804,13 +4804,13 @@
     },
     "extend": {
       "version": "3.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/extend/-/extend-3.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/extend/-/extend-3.0.2.tgz",
       "integrity": "sha1-+LETa0Bx+9jrFAr/hYsQGewpFfo=",
       "dev": true
     },
     "extend-shallow": {
       "version": "3.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/extend-shallow/-/extend-shallow-3.0.2.tgz",
       "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
       "dev": true,
       "requires": {
@@ -4820,7 +4820,7 @@
       "dependencies": {
         "is-extendable": {
           "version": "1.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-extendable/-/is-extendable-1.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-extendable/-/is-extendable-1.0.1.tgz",
           "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
           "dev": true,
           "requires": {
@@ -4831,7 +4831,7 @@
     },
     "external-editor": {
       "version": "3.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/external-editor/-/external-editor-3.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/external-editor/-/external-editor-3.1.0.tgz",
       "integrity": "sha1-ywP3QL764D6k0oPK7SdBqD8zVJU=",
       "dev": true,
       "requires": {
@@ -4842,7 +4842,7 @@
     },
     "extglob": {
       "version": "2.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/extglob/-/extglob-2.0.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/extglob/-/extglob-2.0.4.tgz",
       "integrity": "sha1-rQD+TcYSqSMuhxhxHcXLWrAoVUM=",
       "dev": true,
       "requires": {
@@ -4858,7 +4858,7 @@
       "dependencies": {
         "define-property": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/define-property/-/define-property-1.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
@@ -4867,7 +4867,7 @@
         },
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
@@ -4876,7 +4876,7 @@
         },
         "is-accessor-descriptor": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
           "dev": true,
           "requires": {
@@ -4885,7 +4885,7 @@
         },
         "is-data-descriptor": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
           "dev": true,
           "requires": {
@@ -4894,7 +4894,7 @@
         },
         "is-descriptor": {
           "version": "1.0.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
           "dev": true,
           "requires": {
@@ -4936,7 +4936,7 @@
     },
     "extsprintf": {
       "version": "1.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/extsprintf/-/extsprintf-1.3.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
       "dev": true
     },
@@ -4948,7 +4948,7 @@
     },
     "fast-glob": {
       "version": "3.2.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/fast-glob/-/fast-glob-3.2.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/fast-glob/-/fast-glob-3.2.2.tgz",
       "integrity": "sha1-reGp2RFIll1L98UfcuHKZi0y5j0=",
       "dev": true,
       "requires": {
@@ -4962,25 +4962,25 @@
     },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha1-h0v2nG9ATCtdmcSBNBOZ/VWJJjM=",
       "dev": true
     },
     "fast-levenshtein": {
       "version": "2.0.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
     "fast-safe-stringify": {
       "version": "2.0.7",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
       "integrity": "sha1-EkqohYmSYfaK7bQqfAgN6dpgh0M=",
       "dev": true
     },
     "fastq": {
       "version": "1.8.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/fastq/-/fastq-1.8.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/fastq/-/fastq-1.8.0.tgz",
       "integrity": "sha1-VQ4fn1m7xl/hhctqm02VNXEH9IE=",
       "dev": true,
       "requires": {
@@ -4989,7 +4989,7 @@
     },
     "fd-slicer": {
       "version": "1.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/fd-slicer/-/fd-slicer-1.1.0.tgz",
       "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
       "dev": true,
       "requires": {
@@ -4998,13 +4998,13 @@
     },
     "fecha": {
       "version": "2.3.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/fecha/-/fecha-2.3.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/fecha/-/fecha-2.3.3.tgz",
       "integrity": "sha1-lI50FX3xoy/RsSw6PDzctuydls0=",
       "dev": true
     },
     "fetch-mock": {
       "version": "9.10.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/fetch-mock/-/fetch-mock-9.10.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/fetch-mock/-/fetch-mock-9.10.1.tgz",
       "integrity": "sha1-Hwp6N5VJCVa/TP1fpv+RK8TccdM=",
       "dev": true,
       "requires": {
@@ -5021,7 +5021,7 @@
       "dependencies": {
         "debug": {
           "version": "4.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-4.1.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/debug/-/debug-4.1.1.tgz",
           "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
           "dev": true,
           "requires": {
@@ -5030,7 +5030,7 @@
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.1.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ms/-/ms-2.1.2.tgz",
           "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
           "dev": true
         }
@@ -5038,7 +5038,7 @@
     },
     "figures": {
       "version": "3.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/figures/-/figures-3.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/figures/-/figures-3.2.0.tgz",
       "integrity": "sha1-YlwYvSk8YE3EqN2y/r8MiDQXRq8=",
       "dev": true,
       "requires": {
@@ -5047,7 +5047,7 @@
     },
     "file-entry-cache": {
       "version": "5.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
       "integrity": "sha1-yg9u+m3T1WEzP7FFFQZcL6/fQ5w=",
       "dev": true,
       "requires": {
@@ -5056,19 +5056,19 @@
     },
     "file-uri-to-path": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
       "integrity": "sha1-VTp7hEb/b2hDWcRF8eN6BdrMM90=",
       "dev": true
     },
     "filename-regex": {
       "version": "2.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/filename-regex/-/filename-regex-2.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/filename-regex/-/filename-regex-2.0.1.tgz",
       "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
       "dev": true
     },
     "fill-range": {
       "version": "7.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/fill-range/-/fill-range-7.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/fill-range/-/fill-range-7.0.1.tgz",
       "integrity": "sha1-GRmmp8df44ssfHflGYU12prN2kA=",
       "dev": true,
       "requires": {
@@ -5077,7 +5077,7 @@
     },
     "finalhandler": {
       "version": "1.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/finalhandler/-/finalhandler-1.1.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/finalhandler/-/finalhandler-1.1.2.tgz",
       "integrity": "sha1-t+fQAP/RGTjQ/bBTUG9uur6fWH0=",
       "dev": true,
       "requires": {
@@ -5092,7 +5092,7 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-2.6.9.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/debug/-/debug-2.6.9.tgz",
           "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
           "dev": true,
           "requires": {
@@ -5103,7 +5103,7 @@
     },
     "find-port": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/find-port/-/find-port-1.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/find-port/-/find-port-1.0.1.tgz",
       "integrity": "sha1-2whKbL+ZVk2Zhprnn73s9m6KGFw=",
       "dev": true,
       "requires": {
@@ -5112,7 +5112,7 @@
       "dependencies": {
         "async": {
           "version": "0.2.10",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/async/-/async-0.2.10.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/async/-/async-0.2.10.tgz",
           "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
           "dev": true
         }
@@ -5120,7 +5120,7 @@
     },
     "find-replace": {
       "version": "3.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/find-replace/-/find-replace-3.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/find-replace/-/find-replace-3.0.0.tgz",
       "integrity": "sha1-Pn4j07BRZ6dvdwyfvVJYsN72jDg=",
       "dev": true,
       "requires": {
@@ -5129,7 +5129,7 @@
     },
     "find-up": {
       "version": "3.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/find-up/-/find-up-3.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/find-up/-/find-up-3.0.0.tgz",
       "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
       "dev": true,
       "requires": {
@@ -5138,7 +5138,7 @@
     },
     "findup-sync": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/findup-sync/-/findup-sync-2.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/findup-sync/-/findup-sync-2.0.0.tgz",
       "integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
       "dev": true,
       "requires": {
@@ -5150,7 +5150,7 @@
       "dependencies": {
         "braces": {
           "version": "2.3.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/braces/-/braces-2.3.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/braces/-/braces-2.3.2.tgz",
           "integrity": "sha1-WXn9PxTNUxVl5fot8av/8d+u5yk=",
           "dev": true,
           "requires": {
@@ -5168,7 +5168,7 @@
           "dependencies": {
             "extend-shallow": {
               "version": "2.0.1",
-              "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
@@ -5179,7 +5179,7 @@
         },
         "fill-range": {
           "version": "4.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/fill-range/-/fill-range-4.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/fill-range/-/fill-range-4.0.0.tgz",
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "dev": true,
           "requires": {
@@ -5191,7 +5191,7 @@
           "dependencies": {
             "extend-shallow": {
               "version": "2.0.1",
-              "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
@@ -5202,13 +5202,13 @@
         },
         "is-buffer": {
           "version": "1.1.6",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-buffer/-/is-buffer-1.1.6.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-buffer/-/is-buffer-1.1.6.tgz",
           "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
           "dev": true
         },
         "is-glob": {
           "version": "3.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-glob/-/is-glob-3.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-glob/-/is-glob-3.1.0.tgz",
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
           "dev": true,
           "requires": {
@@ -5217,7 +5217,7 @@
         },
         "is-number": {
           "version": "3.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-number/-/is-number-3.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
@@ -5226,7 +5226,7 @@
           "dependencies": {
             "kind-of": {
               "version": "3.2.2",
-              "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/kind-of/-/kind-of-3.2.2.tgz",
+              "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
@@ -5237,7 +5237,7 @@
         },
         "micromatch": {
           "version": "3.1.10",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/micromatch/-/micromatch-3.1.10.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/micromatch/-/micromatch-3.1.10.tgz",
           "integrity": "sha1-cIWbyVyYQJUvNZoGij/En57PrCM=",
           "dev": true,
           "requires": {
@@ -5258,7 +5258,7 @@
         },
         "to-regex-range": {
           "version": "2.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/to-regex-range/-/to-regex-range-2.1.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/to-regex-range/-/to-regex-range-2.1.1.tgz",
           "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
           "dev": true,
           "requires": {
@@ -5270,13 +5270,13 @@
     },
     "first-chunk-stream": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
       "integrity": "sha1-Wb+1DNkF9g18OUzT2ayqtOatk04=",
       "dev": true
     },
     "flat": {
       "version": "4.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/flat/-/flat-4.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/flat/-/flat-4.1.0.tgz",
       "integrity": "sha1-CQvsiwXjnLowl0fx1YjwTbr5jbI=",
       "dev": true,
       "requires": {
@@ -5285,7 +5285,7 @@
     },
     "flat-cache": {
       "version": "2.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/flat-cache/-/flat-cache-2.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/flat-cache/-/flat-cache-2.0.1.tgz",
       "integrity": "sha1-XSltbwS9pEpGMKMBQTvbwuwIXsA=",
       "dev": true,
       "requires": {
@@ -5296,7 +5296,7 @@
       "dependencies": {
         "rimraf": {
           "version": "2.6.3",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/rimraf/-/rimraf-2.6.3.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/rimraf/-/rimraf-2.6.3.tgz",
           "integrity": "sha1-stEE/g2Psnz54KHNqCYt04M8bKs=",
           "dev": true,
           "requires": {
@@ -5307,13 +5307,13 @@
     },
     "flatted": {
       "version": "2.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/flatted/-/flatted-2.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/flatted/-/flatted-2.0.2.tgz",
       "integrity": "sha1-RXWyHivO50NKqb5mL0t7X5wrUTg=",
       "dev": true
     },
     "follow-redirects": {
       "version": "1.5.10",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/follow-redirects/-/follow-redirects-1.5.10.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/follow-redirects/-/follow-redirects-1.5.10.tgz",
       "integrity": "sha1-e3qfmuov3/NnhqlP9kPtB/T/Xio=",
       "dev": true,
       "requires": {
@@ -5322,13 +5322,13 @@
     },
     "for-in": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/for-in/-/for-in-1.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/for-in/-/for-in-1.0.2.tgz",
       "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
       "dev": true
     },
     "for-own": {
       "version": "0.1.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/for-own/-/for-own-0.1.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/for-own/-/for-own-0.1.5.tgz",
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
       "dev": true,
       "requires": {
@@ -5337,25 +5337,25 @@
     },
     "foreach": {
       "version": "2.0.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/foreach/-/foreach-2.0.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/foreach/-/foreach-2.0.5.tgz",
       "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
       "dev": true
     },
     "forever-agent": {
       "version": "0.6.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/forever-agent/-/forever-agent-0.6.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/forever-agent/-/forever-agent-0.6.1.tgz",
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
       "dev": true
     },
     "fork-stream": {
       "version": "0.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/fork-stream/-/fork-stream-0.0.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/fork-stream/-/fork-stream-0.0.4.tgz",
       "integrity": "sha1-24Sfznf2cIpfjzhq5TOgkHtUrnA=",
       "dev": true
     },
     "form-data": {
       "version": "2.3.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/form-data/-/form-data-2.3.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/form-data/-/form-data-2.3.3.tgz",
       "integrity": "sha1-3M5SwF9kTymManq5Nr1yTO/786Y=",
       "dev": true,
       "requires": {
@@ -5366,7 +5366,7 @@
     },
     "formatio": {
       "version": "1.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/formatio/-/formatio-1.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/formatio/-/formatio-1.1.1.tgz",
       "integrity": "sha1-XtPM1jZVEJc4NGXZlhmRAOhhYek=",
       "dev": true,
       "requires": {
@@ -5375,13 +5375,13 @@
     },
     "forwarded": {
       "version": "0.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/forwarded/-/forwarded-0.1.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/forwarded/-/forwarded-0.1.2.tgz",
       "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
       "dev": true
     },
     "fragment-cache": {
       "version": "0.2.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/fragment-cache/-/fragment-cache-0.2.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/fragment-cache/-/fragment-cache-0.2.1.tgz",
       "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
       "dev": true,
       "requires": {
@@ -5390,32 +5390,32 @@
     },
     "freeport": {
       "version": "1.0.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/freeport/-/freeport-1.0.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/freeport/-/freeport-1.0.5.tgz",
       "integrity": "sha1-JV6KuEFwwzuoXZkOghrl9KGpvF0=",
       "dev": true,
       "optional": true
     },
     "fresh": {
       "version": "0.5.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/fresh/-/fresh-0.5.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
       "dev": true
     },
     "from": {
       "version": "0.1.7",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/from/-/from-0.1.7.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/from/-/from-0.1.7.tgz",
       "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
       "dev": true
     },
     "fs-constants": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/fs-constants/-/fs-constants-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/fs-constants/-/fs-constants-1.0.0.tgz",
       "integrity": "sha1-a+Dem+mYzhavivwkSXue6bfM2a0=",
       "dev": true
     },
     "fs-minipass": {
       "version": "1.2.7",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/fs-minipass/-/fs-minipass-1.2.7.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/fs-minipass/-/fs-minipass-1.2.7.tgz",
       "integrity": "sha1-zP+FcIQef+QmVpPaiJNsVa7X98c=",
       "dev": true,
       "requires": {
@@ -5424,20 +5424,20 @@
     },
     "fs.realpath": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
     "fsevents": {
       "version": "2.1.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/fsevents/-/fsevents-2.1.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/fsevents/-/fsevents-2.1.3.tgz",
       "integrity": "sha1-+3OHA66NL5/pAMM4Nt3r7ouX8j4=",
       "dev": true,
       "optional": true
     },
     "fstream": {
       "version": "1.0.12",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/fstream/-/fstream-1.0.12.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/fstream/-/fstream-1.0.12.tgz",
       "integrity": "sha1-Touo7i1Ivk99DeUFRVVI6uWTIEU=",
       "dev": true,
       "requires": {
@@ -5449,19 +5449,19 @@
     },
     "function-bind": {
       "version": "1.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/function-bind/-/function-bind-1.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0=",
       "dev": true
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
     },
     "gauge": {
       "version": "2.7.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/gauge/-/gauge-2.7.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/gauge/-/gauge-2.7.4.tgz",
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
       "dev": true,
       "requires": {
@@ -5477,7 +5477,7 @@
     },
     "geckodriver": {
       "version": "1.19.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/geckodriver/-/geckodriver-1.19.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/geckodriver/-/geckodriver-1.19.1.tgz",
       "integrity": "sha1-VW+V/WRRtVPOyJ+B+Bq7784Q1uU=",
       "dev": true,
       "requires": {
@@ -5490,7 +5490,7 @@
       "dependencies": {
         "tar": {
           "version": "4.4.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/tar/-/tar-4.4.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/tar/-/tar-4.4.2.tgz",
           "integrity": "sha1-YGhSEbpGs4hHsa5+4aJNdEos1GI=",
           "dev": true,
           "requires": {
@@ -5507,31 +5507,31 @@
     },
     "gensync": {
       "version": "1.0.0-beta.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/gensync/-/gensync-1.0.0-beta.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/gensync/-/gensync-1.0.0-beta.1.tgz",
       "integrity": "sha1-WPQ2H/mH5f9uHnohCCeqNx6qwmk=",
       "dev": true
     },
     "get-caller-file": {
       "version": "2.0.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha1-T5RBKoLbMvNuOwuXQfipf+sDH34=",
       "dev": true
     },
     "get-func-name": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/get-func-name/-/get-func-name-2.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/get-func-name/-/get-func-name-2.0.0.tgz",
       "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
       "dev": true
     },
     "get-stdin": {
       "version": "4.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/get-stdin/-/get-stdin-4.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/get-stdin/-/get-stdin-4.0.1.tgz",
       "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
       "dev": true
     },
     "get-stream": {
       "version": "5.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/get-stream/-/get-stream-5.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/get-stream/-/get-stream-5.1.0.tgz",
       "integrity": "sha1-ASA83JJZf5uQkGfD5lbMH008Tck=",
       "dev": true,
       "requires": {
@@ -5540,13 +5540,13 @@
     },
     "get-value": {
       "version": "2.0.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/get-value/-/get-value-2.0.6.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/get-value/-/get-value-2.0.6.tgz",
       "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
       "dev": true
     },
     "getpass": {
       "version": "0.1.7",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/getpass/-/getpass-0.1.7.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
       "requires": {
@@ -5555,13 +5555,13 @@
     },
     "github-url-from-git": {
       "version": "1.5.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/github-url-from-git/-/github-url-from-git-1.5.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/github-url-from-git/-/github-url-from-git-1.5.0.tgz",
       "integrity": "sha1-+YX+3MCpqledyI16/waNVcxiUaA=",
       "dev": true
     },
     "glob": {
       "version": "7.1.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/glob/-/glob-7.1.6.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/glob/-/glob-7.1.6.tgz",
       "integrity": "sha1-FB8zuBp8JJLhJVlDB0gMRmeSeKY=",
       "dev": true,
       "requires": {
@@ -5575,7 +5575,7 @@
     },
     "glob-base": {
       "version": "0.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/glob-base/-/glob-base-0.3.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/glob-base/-/glob-base-0.3.0.tgz",
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
       "dev": true,
       "requires": {
@@ -5585,7 +5585,7 @@
       "dependencies": {
         "glob-parent": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/glob-parent/-/glob-parent-2.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/glob-parent/-/glob-parent-2.0.0.tgz",
           "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
           "dev": true,
           "requires": {
@@ -5594,13 +5594,13 @@
         },
         "is-extglob": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-extglob/-/is-extglob-1.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-extglob/-/is-extglob-1.0.0.tgz",
           "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
           "dev": true
         },
         "is-glob": {
           "version": "2.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-glob/-/is-glob-2.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-glob/-/is-glob-2.0.1.tgz",
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
           "requires": {
@@ -5611,7 +5611,7 @@
     },
     "glob-parent": {
       "version": "5.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/glob-parent/-/glob-parent-5.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/glob-parent/-/glob-parent-5.1.1.tgz",
       "integrity": "sha1-tsHvQXxOVmPqSY8cRa+saRa7wik=",
       "dev": true,
       "requires": {
@@ -5620,7 +5620,7 @@
     },
     "glob-stream": {
       "version": "5.3.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/glob-stream/-/glob-stream-5.3.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/glob-stream/-/glob-stream-5.3.5.tgz",
       "integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
       "dev": true,
       "requires": {
@@ -5636,7 +5636,7 @@
       "dependencies": {
         "arr-diff": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/arr-diff/-/arr-diff-2.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/arr-diff/-/arr-diff-2.0.0.tgz",
           "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
           "dev": true,
           "requires": {
@@ -5645,13 +5645,13 @@
         },
         "array-unique": {
           "version": "0.2.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/array-unique/-/array-unique-0.2.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/array-unique/-/array-unique-0.2.1.tgz",
           "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
           "dev": true
         },
         "braces": {
           "version": "1.8.5",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/braces/-/braces-1.8.5.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/braces/-/braces-1.8.5.tgz",
           "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
           "dev": true,
           "requires": {
@@ -5662,7 +5662,7 @@
         },
         "expand-brackets": {
           "version": "0.1.5",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/expand-brackets/-/expand-brackets-0.1.5.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/expand-brackets/-/expand-brackets-0.1.5.tgz",
           "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
           "dev": true,
           "requires": {
@@ -5671,7 +5671,7 @@
         },
         "extglob": {
           "version": "0.3.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/extglob/-/extglob-0.3.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/extglob/-/extglob-0.3.2.tgz",
           "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
           "dev": true,
           "requires": {
@@ -5680,7 +5680,7 @@
           "dependencies": {
             "is-extglob": {
               "version": "1.0.0",
-              "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-extglob/-/is-extglob-1.0.0.tgz",
+              "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-extglob/-/is-extglob-1.0.0.tgz",
               "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
               "dev": true
             }
@@ -5688,7 +5688,7 @@
         },
         "glob": {
           "version": "5.0.15",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/glob/-/glob-5.0.15.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/glob/-/glob-5.0.15.tgz",
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
           "dev": true,
           "requires": {
@@ -5701,7 +5701,7 @@
         },
         "glob-parent": {
           "version": "3.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/glob-parent/-/glob-parent-3.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/glob-parent/-/glob-parent-3.1.0.tgz",
           "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
           "dev": true,
           "requires": {
@@ -5711,13 +5711,13 @@
         },
         "is-buffer": {
           "version": "1.1.6",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-buffer/-/is-buffer-1.1.6.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-buffer/-/is-buffer-1.1.6.tgz",
           "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
           "dev": true
         },
         "is-glob": {
           "version": "3.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-glob/-/is-glob-3.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-glob/-/is-glob-3.1.0.tgz",
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
           "dev": true,
           "requires": {
@@ -5726,7 +5726,7 @@
         },
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
@@ -5735,7 +5735,7 @@
         },
         "micromatch": {
           "version": "2.3.11",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/micromatch/-/micromatch-2.3.11.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/micromatch/-/micromatch-2.3.11.tgz",
           "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
           "dev": true,
           "requires": {
@@ -5756,13 +5756,13 @@
           "dependencies": {
             "is-extglob": {
               "version": "1.0.0",
-              "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-extglob/-/is-extglob-1.0.0.tgz",
+              "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-extglob/-/is-extglob-1.0.0.tgz",
               "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
               "dev": true
             },
             "is-glob": {
               "version": "2.0.1",
-              "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-glob/-/is-glob-2.0.1.tgz",
+              "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-glob/-/is-glob-2.0.1.tgz",
               "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
               "dev": true,
               "requires": {
@@ -5773,7 +5773,7 @@
         },
         "normalize-path": {
           "version": "2.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/normalize-path/-/normalize-path-2.1.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/normalize-path/-/normalize-path-2.1.1.tgz",
           "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
           "dev": true,
           "requires": {
@@ -5782,7 +5782,7 @@
         },
         "readable-stream": {
           "version": "1.0.34",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/readable-stream/-/readable-stream-1.0.34.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
@@ -5794,7 +5794,7 @@
         },
         "through2": {
           "version": "0.6.5",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/through2/-/through2-0.6.5.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/through2/-/through2-0.6.5.tgz",
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
           "dev": true,
           "requires": {
@@ -5806,13 +5806,13 @@
     },
     "glob-to-regexp": {
       "version": "0.4.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
       "integrity": "sha1-x1KXCHyFG5pXi9IX3VmpL1n+VG4=",
       "dev": true
     },
     "global-dirs": {
       "version": "2.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/global-dirs/-/global-dirs-2.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/global-dirs/-/global-dirs-2.0.1.tgz",
       "integrity": "sha1-rN87tmhbzVXLNeigUiZlaelGkgE=",
       "dev": true,
       "requires": {
@@ -5821,7 +5821,7 @@
     },
     "global-modules": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/global-modules/-/global-modules-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/global-modules/-/global-modules-1.0.0.tgz",
       "integrity": "sha1-bXcPDrUjrHgWTXK15xqIdyZcw+o=",
       "dev": true,
       "requires": {
@@ -5832,7 +5832,7 @@
     },
     "global-prefix": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/global-prefix/-/global-prefix-1.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/global-prefix/-/global-prefix-1.0.2.tgz",
       "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
       "dev": true,
       "requires": {
@@ -5845,7 +5845,7 @@
     },
     "globals": {
       "version": "12.4.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/globals/-/globals-12.4.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/globals/-/globals-12.4.0.tgz",
       "integrity": "sha1-oYgTV2pBsAokqX5/gVkYwuGZJfg=",
       "dev": true,
       "requires": {
@@ -5854,7 +5854,7 @@
     },
     "globby": {
       "version": "10.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/globby/-/globby-10.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/globby/-/globby-10.0.2.tgz",
       "integrity": "sha1-J3WT50WsqkZGw6tBEonsR6A5JUM=",
       "dev": true,
       "requires": {
@@ -5870,7 +5870,7 @@
     },
     "good-listener": {
       "version": "1.2.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/good-listener/-/good-listener-1.2.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/good-listener/-/good-listener-1.2.2.tgz",
       "integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
       "dev": true,
       "optional": true,
@@ -5880,7 +5880,7 @@
     },
     "got": {
       "version": "5.6.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/got/-/got-5.6.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/got/-/got-5.6.0.tgz",
       "integrity": "sha1-ux1+4WO3gIK7yOuDbz85UATqb78=",
       "dev": true,
       "requires": {
@@ -5904,25 +5904,25 @@
     },
     "graceful-fs": {
       "version": "4.2.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/graceful-fs/-/graceful-fs-4.2.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/graceful-fs/-/graceful-fs-4.2.4.tgz",
       "integrity": "sha1-Ila94U02MpWMRl68ltxGfKB6Kfs=",
       "dev": true
     },
     "graceful-readlink": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
       "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
       "dev": true
     },
     "growl": {
       "version": "1.10.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/growl/-/growl-1.10.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/growl/-/growl-1.10.5.tgz",
       "integrity": "sha1-8nNdwig2dPpnR4sQGBBZNVw2nl4=",
       "dev": true
     },
     "gulp-if": {
       "version": "2.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/gulp-if/-/gulp-if-2.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/gulp-if/-/gulp-if-2.0.2.tgz",
       "integrity": "sha1-pJe351cwBQQcqivIt92jyARE1ik=",
       "dev": true,
       "requires": {
@@ -5933,7 +5933,7 @@
     },
     "gulp-match": {
       "version": "1.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/gulp-match/-/gulp-match-1.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/gulp-match/-/gulp-match-1.1.0.tgz",
       "integrity": "sha1-VStwgPwAbudSyQVj+f7J1hqv308=",
       "dev": true,
       "requires": {
@@ -5942,7 +5942,7 @@
     },
     "gulp-sourcemaps": {
       "version": "1.6.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
       "integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
       "dev": true,
       "requires": {
@@ -5955,13 +5955,13 @@
     },
     "handle-thing": {
       "version": "1.2.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/handle-thing/-/handle-thing-1.2.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/handle-thing/-/handle-thing-1.2.5.tgz",
       "integrity": "sha1-/Xqtcmvxpf0W38KbL3pmAdJxOcQ=",
       "dev": true
     },
     "handlebars": {
       "version": "4.7.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/handlebars/-/handlebars-4.7.6.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/handlebars/-/handlebars-4.7.6.tgz",
       "integrity": "sha1-1MBcG6+Q6ZRfd6pop6IZqkp9904=",
       "dev": true,
       "requires": {
@@ -5974,13 +5974,13 @@
     },
     "har-schema": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/har-schema/-/har-schema-2.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/har-schema/-/har-schema-2.0.0.tgz",
       "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
       "dev": true
     },
     "har-validator": {
       "version": "5.1.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/har-validator/-/har-validator-5.1.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/har-validator/-/har-validator-5.1.3.tgz",
       "integrity": "sha1-HvievT5JllV2de7ZiTEQ3DUPoIA=",
       "dev": true,
       "requires": {
@@ -5990,13 +5990,13 @@
     },
     "hard-rejection": {
       "version": "2.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/hard-rejection/-/hard-rejection-2.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/hard-rejection/-/hard-rejection-2.1.0.tgz",
       "integrity": "sha1-HG7aXBaFxjlCdm15u0Cudzzs2IM=",
       "dev": true
     },
     "has": {
       "version": "1.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/has/-/has-1.0.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/has/-/has-1.0.3.tgz",
       "integrity": "sha1-ci18v8H2qoJB8W3YFOAR4fQeh5Y=",
       "dev": true,
       "requires": {
@@ -6005,7 +6005,7 @@
     },
     "has-ansi": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/has-ansi/-/has-ansi-2.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
@@ -6014,7 +6014,7 @@
     },
     "has-binary2": {
       "version": "1.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/has-binary2/-/has-binary2-1.0.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/has-binary2/-/has-binary2-1.0.3.tgz",
       "integrity": "sha1-d3asYn8+p3JQz8My2rfd9eT10R0=",
       "dev": true,
       "requires": {
@@ -6023,7 +6023,7 @@
       "dependencies": {
         "isarray": {
           "version": "2.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/isarray/-/isarray-2.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/isarray/-/isarray-2.0.1.tgz",
           "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4=",
           "dev": true
         }
@@ -6031,37 +6031,37 @@
     },
     "has-color": {
       "version": "0.1.7",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/has-color/-/has-color-0.1.7.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/has-color/-/has-color-0.1.7.tgz",
       "integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8=",
       "dev": true
     },
     "has-cors": {
       "version": "1.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/has-cors/-/has-cors-1.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/has-cors/-/has-cors-1.1.0.tgz",
       "integrity": "sha1-XkdHk/fqmEPRu5nCPu9J/xJv/zk=",
       "dev": true
     },
     "has-flag": {
       "version": "3.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/has-flag/-/has-flag-3.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
     },
     "has-symbols": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/has-symbols/-/has-symbols-1.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/has-symbols/-/has-symbols-1.0.1.tgz",
       "integrity": "sha1-n1IUdYpEGWxAbZvXbOv4HsLdMeg=",
       "dev": true
     },
     "has-unicode": {
       "version": "2.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/has-unicode/-/has-unicode-2.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/has-unicode/-/has-unicode-2.0.1.tgz",
       "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
       "dev": true
     },
     "has-value": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/has-value/-/has-value-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/has-value/-/has-value-1.0.0.tgz",
       "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
       "dev": true,
       "requires": {
@@ -6072,7 +6072,7 @@
     },
     "has-values": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/has-values/-/has-values-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/has-values/-/has-values-1.0.0.tgz",
       "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
       "dev": true,
       "requires": {
@@ -6082,13 +6082,13 @@
       "dependencies": {
         "is-buffer": {
           "version": "1.1.6",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-buffer/-/is-buffer-1.1.6.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-buffer/-/is-buffer-1.1.6.tgz",
           "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
           "dev": true
         },
         "is-number": {
           "version": "3.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-number/-/is-number-3.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
@@ -6097,7 +6097,7 @@
           "dependencies": {
             "kind-of": {
               "version": "3.2.2",
-              "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/kind-of/-/kind-of-3.2.2.tgz",
+              "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
@@ -6108,7 +6108,7 @@
         },
         "kind-of": {
           "version": "4.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/kind-of/-/kind-of-4.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/kind-of/-/kind-of-4.0.0.tgz",
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "dev": true,
           "requires": {
@@ -6119,19 +6119,19 @@
     },
     "has-yarn": {
       "version": "2.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/has-yarn/-/has-yarn-2.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/has-yarn/-/has-yarn-2.1.0.tgz",
       "integrity": "sha1-E34RNUp7W/EapctknPDG8/8rLnc=",
       "dev": true
     },
     "he": {
       "version": "1.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/he/-/he-1.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/he/-/he-1.2.0.tgz",
       "integrity": "sha1-hK5l+n6vsWX922FWauFLrwVmTw8=",
       "dev": true
     },
     "homedir-polyfill": {
       "version": "1.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
       "integrity": "sha1-dDKYzvTlrz4ZQWH7rcwhUdOgWOg=",
       "dev": true,
       "requires": {
@@ -6140,7 +6140,7 @@
     },
     "hosted-git-info": {
       "version": "3.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/hosted-git-info/-/hosted-git-info-3.0.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/hosted-git-info/-/hosted-git-info-3.0.4.tgz",
       "integrity": "sha1-vklz6x/Sc3sRycfBk4Bzm7JJ9g0=",
       "dev": true,
       "requires": {
@@ -6149,7 +6149,7 @@
     },
     "hpack.js": {
       "version": "2.1.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/hpack.js/-/hpack.js-2.1.6.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/hpack.js/-/hpack.js-2.1.6.tgz",
       "integrity": "sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=",
       "dev": true,
       "requires": {
@@ -6161,7 +6161,7 @@
     },
     "html-encoding-sniffer": {
       "version": "2.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz",
       "integrity": "sha1-QqbcT9M/ACgRduiyN1nKTk+hhfM=",
       "dev": true,
       "requires": {
@@ -6170,7 +6170,7 @@
     },
     "html-minifier": {
       "version": "4.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/html-minifier/-/html-minifier-4.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/html-minifier/-/html-minifier-4.0.0.tgz",
       "integrity": "sha1-zKmq2LzhF14C4XqMM+RtiYiIn1Y=",
       "dev": true,
       "requires": {
@@ -6185,7 +6185,7 @@
     },
     "htmlparser2": {
       "version": "4.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/htmlparser2/-/htmlparser2-4.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/htmlparser2/-/htmlparser2-4.1.0.tgz",
       "integrity": "sha1-mk7xYfLkYl6/ffvmwKL1LRilnng=",
       "dev": true,
       "requires": {
@@ -6197,19 +6197,19 @@
     },
     "http-cache-semantics": {
       "version": "4.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
       "integrity": "sha1-SekcXL82yblLz81xwj1SSex045A=",
       "dev": true
     },
     "http-deceiver": {
       "version": "1.2.7",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/http-deceiver/-/http-deceiver-1.2.7.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/http-deceiver/-/http-deceiver-1.2.7.tgz",
       "integrity": "sha1-+nFolEq5pRnTN8sL7HKE3D5yPYc=",
       "dev": true
     },
     "http-errors": {
       "version": "1.7.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/http-errors/-/http-errors-1.7.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/http-errors/-/http-errors-1.7.2.tgz",
       "integrity": "sha1-T1ApzxMjnzEDblsuVSkrz7zIXI8=",
       "dev": true,
       "requires": {
@@ -6222,7 +6222,7 @@
       "dependencies": {
         "inherits": {
           "version": "2.0.3",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/inherits/-/inherits-2.0.3.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true
         }
@@ -6230,7 +6230,7 @@
     },
     "http-proxy": {
       "version": "1.18.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/http-proxy/-/http-proxy-1.18.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/http-proxy/-/http-proxy-1.18.1.tgz",
       "integrity": "sha1-QBVB8FNIhLv5UmAzTnL4juOXZUk=",
       "dev": true,
       "requires": {
@@ -6241,7 +6241,7 @@
     },
     "http-proxy-middleware": {
       "version": "0.17.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/http-proxy-middleware/-/http-proxy-middleware-0.17.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/http-proxy-middleware/-/http-proxy-middleware-0.17.4.tgz",
       "integrity": "sha1-ZC6ISIUdZvCdTxJJEoRtuutBuDM=",
       "dev": true,
       "requires": {
@@ -6253,7 +6253,7 @@
       "dependencies": {
         "arr-diff": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/arr-diff/-/arr-diff-2.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/arr-diff/-/arr-diff-2.0.0.tgz",
           "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
           "dev": true,
           "requires": {
@@ -6262,13 +6262,13 @@
         },
         "array-unique": {
           "version": "0.2.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/array-unique/-/array-unique-0.2.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/array-unique/-/array-unique-0.2.1.tgz",
           "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
           "dev": true
         },
         "braces": {
           "version": "1.8.5",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/braces/-/braces-1.8.5.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/braces/-/braces-1.8.5.tgz",
           "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
           "dev": true,
           "requires": {
@@ -6279,7 +6279,7 @@
         },
         "expand-brackets": {
           "version": "0.1.5",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/expand-brackets/-/expand-brackets-0.1.5.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/expand-brackets/-/expand-brackets-0.1.5.tgz",
           "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
           "dev": true,
           "requires": {
@@ -6288,7 +6288,7 @@
         },
         "extglob": {
           "version": "0.3.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/extglob/-/extglob-0.3.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/extglob/-/extglob-0.3.2.tgz",
           "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
           "dev": true,
           "requires": {
@@ -6297,7 +6297,7 @@
           "dependencies": {
             "is-extglob": {
               "version": "1.0.0",
-              "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-extglob/-/is-extglob-1.0.0.tgz",
+              "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-extglob/-/is-extglob-1.0.0.tgz",
               "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
               "dev": true
             }
@@ -6305,13 +6305,13 @@
         },
         "is-buffer": {
           "version": "1.1.6",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-buffer/-/is-buffer-1.1.6.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-buffer/-/is-buffer-1.1.6.tgz",
           "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
           "dev": true
         },
         "is-glob": {
           "version": "3.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-glob/-/is-glob-3.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-glob/-/is-glob-3.1.0.tgz",
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
           "dev": true,
           "requires": {
@@ -6320,7 +6320,7 @@
         },
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
@@ -6329,7 +6329,7 @@
         },
         "micromatch": {
           "version": "2.3.11",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/micromatch/-/micromatch-2.3.11.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/micromatch/-/micromatch-2.3.11.tgz",
           "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
           "dev": true,
           "requires": {
@@ -6350,13 +6350,13 @@
           "dependencies": {
             "is-extglob": {
               "version": "1.0.0",
-              "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-extglob/-/is-extglob-1.0.0.tgz",
+              "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-extglob/-/is-extglob-1.0.0.tgz",
               "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
               "dev": true
             },
             "is-glob": {
               "version": "2.0.1",
-              "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-glob/-/is-glob-2.0.1.tgz",
+              "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-glob/-/is-glob-2.0.1.tgz",
               "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
               "dev": true,
               "requires": {
@@ -6367,7 +6367,7 @@
         },
         "normalize-path": {
           "version": "2.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/normalize-path/-/normalize-path-2.1.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/normalize-path/-/normalize-path-2.1.1.tgz",
           "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
           "dev": true,
           "requires": {
@@ -6378,7 +6378,7 @@
     },
     "http-server": {
       "version": "0.12.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/http-server/-/http-server-0.12.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/http-server/-/http-server-0.12.3.tgz",
       "integrity": "sha1-ugRx0OzEJYhmFss1xPryeRQKDTc=",
       "dev": true,
       "requires": {
@@ -6396,7 +6396,7 @@
     },
     "http-signature": {
       "version": "1.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/http-signature/-/http-signature-1.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "dev": true,
       "requires": {
@@ -6407,7 +6407,7 @@
     },
     "https-proxy-agent": {
       "version": "3.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/https-proxy-agent/-/https-proxy-agent-3.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/https-proxy-agent/-/https-proxy-agent-3.0.0.tgz",
       "integrity": "sha1-AQbvpdY9bW86uHyZn6SHej/R/5c=",
       "dev": true,
       "requires": {
@@ -6417,13 +6417,13 @@
     },
     "human-signals": {
       "version": "1.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/human-signals/-/human-signals-1.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/human-signals/-/human-signals-1.1.1.tgz",
       "integrity": "sha1-xbHNFPUK6uCatsWf5jujOV/k36M=",
       "dev": true
     },
     "icon-font-generator": {
       "version": "2.1.10",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/icon-font-generator/-/icon-font-generator-2.1.10.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/icon-font-generator/-/icon-font-generator-2.1.10.tgz",
       "integrity": "sha1-ldbX88RNxopfvDey4alRFIc4fro=",
       "dev": true,
       "requires": {
@@ -6435,7 +6435,7 @@
     },
     "iconv-lite": {
       "version": "0.4.24",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha1-ICK0sl+93CHS9SSXSkdKr+czkIs=",
       "dev": true,
       "requires": {
@@ -6444,25 +6444,25 @@
     },
     "ieee754": {
       "version": "1.1.13",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ieee754/-/ieee754-1.1.13.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ieee754/-/ieee754-1.1.13.tgz",
       "integrity": "sha1-7BaFWOlaoYH9h9N/VcMrvLZwi4Q=",
       "dev": true
     },
     "ignore": {
       "version": "5.1.8",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ignore/-/ignore-5.1.8.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ignore/-/ignore-5.1.8.tgz",
       "integrity": "sha1-8VCotQo0KJsz4i9YiavU2AFvDlc=",
       "dev": true
     },
     "immediate": {
       "version": "3.0.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/immediate/-/immediate-3.0.6.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/immediate/-/immediate-3.0.6.tgz",
       "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=",
       "dev": true
     },
     "import-fresh": {
       "version": "3.2.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/import-fresh/-/import-fresh-3.2.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/import-fresh/-/import-fresh-3.2.1.tgz",
       "integrity": "sha1-Yz/2GFBueTr1rJG/SLcmd+FcvmY=",
       "dev": true,
       "requires": {
@@ -6472,37 +6472,37 @@
     },
     "import-lazy": {
       "version": "2.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/import-lazy/-/import-lazy-2.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/import-lazy/-/import-lazy-2.1.0.tgz",
       "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
       "dev": true
     },
     "imurmurhash": {
       "version": "0.1.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true
     },
     "indent": {
       "version": "0.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/indent/-/indent-0.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/indent/-/indent-0.0.2.tgz",
       "integrity": "sha1-jHnwgBkFWbaHA0uEx676l9WpEdk=",
       "dev": true
     },
     "indent-string": {
       "version": "4.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/indent-string/-/indent-string-4.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/indent-string/-/indent-string-4.0.0.tgz",
       "integrity": "sha1-Yk+PRJfWGbLZdoUx1Y9BIoVNclE=",
       "dev": true
     },
     "indexof": {
       "version": "0.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/indexof/-/indexof-0.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/indexof/-/indexof-0.0.1.tgz",
       "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=",
       "dev": true
     },
     "inflight": {
       "version": "1.0.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/inflight/-/inflight-1.0.6.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
@@ -6512,19 +6512,19 @@
     },
     "inherits": {
       "version": "2.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/inherits/-/inherits-2.0.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w=",
       "dev": true
     },
     "ini": {
       "version": "1.3.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ini/-/ini-1.3.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ini/-/ini-1.3.5.tgz",
       "integrity": "sha1-7uJfVtscnsYIXgwid4CD9Zar+Sc=",
       "dev": true
     },
     "inquirer": {
       "version": "7.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/inquirer/-/inquirer-7.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/inquirer/-/inquirer-7.1.0.tgz",
       "integrity": "sha1-EpigGFmIPhfHJkuChwrhA0+S3Sk=",
       "dev": true,
       "requires": {
@@ -6545,13 +6545,13 @@
       "dependencies": {
         "ansi-regex": {
           "version": "5.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-5.0.0.tgz",
           "integrity": "sha1-OIU59VF5vzkznIGvMKZU1p+Hy3U=",
           "dev": true
         },
         "ansi-styles": {
           "version": "4.2.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-styles/-/ansi-styles-4.2.1.tgz",
           "integrity": "sha1-kK51xCTQCNJiTFvynq0xd+v881k=",
           "dev": true,
           "requires": {
@@ -6561,7 +6561,7 @@
         },
         "chalk": {
           "version": "3.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/chalk/-/chalk-3.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/chalk/-/chalk-3.0.0.tgz",
           "integrity": "sha1-P3PCv1JlkfV0zEksUeJFY0n4ROQ=",
           "dev": true,
           "requires": {
@@ -6571,7 +6571,7 @@
         },
         "color-convert": {
           "version": "2.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/color-convert/-/color-convert-2.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/color-convert/-/color-convert-2.0.1.tgz",
           "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
           "dev": true,
           "requires": {
@@ -6580,25 +6580,25 @@
         },
         "color-name": {
           "version": "1.1.4",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/color-name/-/color-name-1.1.4.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
           "dev": true
         },
         "has-flag": {
           "version": "4.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/has-flag/-/has-flag-4.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
           "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "3.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
           "integrity": "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0=",
           "dev": true
         },
         "string-width": {
           "version": "4.2.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string-width/-/string-width-4.2.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/string-width/-/string-width-4.2.0.tgz",
           "integrity": "sha1-lSGCxGzHssMT0VluYjmSvRY7crU=",
           "dev": true,
           "requires": {
@@ -6609,7 +6609,7 @@
         },
         "strip-ansi": {
           "version": "6.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-6.0.0.tgz",
           "integrity": "sha1-CxVx3XZpzNTz4G4U7x7tJiJa5TI=",
           "dev": true,
           "requires": {
@@ -6618,7 +6618,7 @@
         },
         "supports-color": {
           "version": "7.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/supports-color/-/supports-color-7.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/supports-color/-/supports-color-7.1.0.tgz",
           "integrity": "sha1-aOMlkd9z4lrRxLSRCKLsUHliv9E=",
           "dev": true,
           "requires": {
@@ -6629,7 +6629,7 @@
     },
     "inquirer-autosubmit-prompt": {
       "version": "0.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/inquirer-autosubmit-prompt/-/inquirer-autosubmit-prompt-0.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/inquirer-autosubmit-prompt/-/inquirer-autosubmit-prompt-0.2.0.tgz",
       "integrity": "sha1-oQ+VKvT3usnEMBDj6eCJHX6NFaE=",
       "dev": true,
       "requires": {
@@ -6640,19 +6640,19 @@
       "dependencies": {
         "ansi-escapes": {
           "version": "3.2.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
           "integrity": "sha1-h4C5j/nb9WOBUtHx/lwde0RCl2s=",
           "dev": true
         },
         "ansi-regex": {
           "version": "3.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
         "chalk": {
           "version": "2.4.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/chalk/-/chalk-2.4.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
           "dev": true,
           "requires": {
@@ -6663,7 +6663,7 @@
         },
         "cli-cursor": {
           "version": "2.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cli-cursor/-/cli-cursor-2.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/cli-cursor/-/cli-cursor-2.1.0.tgz",
           "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
           "dev": true,
           "requires": {
@@ -6672,7 +6672,7 @@
         },
         "figures": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/figures/-/figures-2.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/figures/-/figures-2.0.0.tgz",
           "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
           "dev": true,
           "requires": {
@@ -6681,7 +6681,7 @@
         },
         "inquirer": {
           "version": "6.5.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/inquirer/-/inquirer-6.5.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/inquirer/-/inquirer-6.5.2.tgz",
           "integrity": "sha1-rVCUI3XQNtMn/1KMCL1fqwiZKMo=",
           "dev": true,
           "requires": {
@@ -6702,25 +6702,25 @@
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
         "mimic-fn": {
           "version": "1.2.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mimic-fn/-/mimic-fn-1.2.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/mimic-fn/-/mimic-fn-1.2.0.tgz",
           "integrity": "sha1-ggyGo5M0ZA6ZUWkovQP8qIBX0CI=",
           "dev": true
         },
         "mute-stream": {
           "version": "0.0.7",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mute-stream/-/mute-stream-0.0.7.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/mute-stream/-/mute-stream-0.0.7.tgz",
           "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
           "dev": true
         },
         "onetime": {
           "version": "2.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/onetime/-/onetime-2.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/onetime/-/onetime-2.0.1.tgz",
           "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
           "dev": true,
           "requires": {
@@ -6729,7 +6729,7 @@
         },
         "restore-cursor": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/restore-cursor/-/restore-cursor-2.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/restore-cursor/-/restore-cursor-2.0.0.tgz",
           "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
           "dev": true,
           "requires": {
@@ -6739,7 +6739,7 @@
         },
         "string-width": {
           "version": "2.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string-width/-/string-width-2.1.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/string-width/-/string-width-2.1.1.tgz",
           "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
           "dev": true,
           "requires": {
@@ -6749,7 +6749,7 @@
           "dependencies": {
             "strip-ansi": {
               "version": "4.0.0",
-              "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-4.0.0.tgz",
+              "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-4.0.0.tgz",
               "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "dev": true,
               "requires": {
@@ -6760,7 +6760,7 @@
         },
         "strip-ansi": {
           "version": "5.2.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
           "dev": true,
           "requires": {
@@ -6769,7 +6769,7 @@
           "dependencies": {
             "ansi-regex": {
               "version": "4.1.0",
-              "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-4.1.0.tgz",
+              "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-4.1.0.tgz",
               "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc=",
               "dev": true
             }
@@ -6779,13 +6779,13 @@
     },
     "intersection-observer": {
       "version": "0.5.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/intersection-observer/-/intersection-observer-0.5.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/intersection-observer/-/intersection-observer-0.5.1.tgz",
       "integrity": "sha1-40D8Vs50KQ/isjlNHOiMQ1Osbfo=",
       "dev": true
     },
     "invariant": {
       "version": "2.2.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/invariant/-/invariant-2.2.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/invariant/-/invariant-2.2.4.tgz",
       "integrity": "sha1-YQ88ksk1nOHbYW5TgAjSP/NRWOY=",
       "dev": true,
       "requires": {
@@ -6800,19 +6800,19 @@
     },
     "ip-regex": {
       "version": "2.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ip-regex/-/ip-regex-2.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ip-regex/-/ip-regex-2.1.0.tgz",
       "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=",
       "dev": true
     },
     "ipaddr.js": {
       "version": "1.9.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
       "integrity": "sha1-v/OFQ+64mEglB5/zoqjmy9RngbM=",
       "dev": true
     },
     "is-accessor-descriptor": {
       "version": "0.1.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
       "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "dev": true,
       "requires": {
@@ -6821,13 +6821,13 @@
       "dependencies": {
         "is-buffer": {
           "version": "1.1.6",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-buffer/-/is-buffer-1.1.6.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-buffer/-/is-buffer-1.1.6.tgz",
           "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
           "dev": true
         },
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
@@ -6838,19 +6838,19 @@
     },
     "is-arguments": {
       "version": "1.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-arguments/-/is-arguments-1.0.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-arguments/-/is-arguments-1.0.4.tgz",
       "integrity": "sha1-P6+WbHy6D/Q3+zH2JQCC/PBEjPM=",
       "dev": true
     },
     "is-arrayish": {
       "version": "0.2.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
     },
     "is-binary-path": {
       "version": "2.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha1-6h9/O4DwZCNug0cPhsCcJU+0Wwk=",
       "dev": true,
       "requires": {
@@ -6859,19 +6859,19 @@
     },
     "is-buffer": {
       "version": "2.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-buffer/-/is-buffer-2.0.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-buffer/-/is-buffer-2.0.4.tgz",
       "integrity": "sha1-PlcvI8hBGlz9lVfISeNmXgspBiM=",
       "dev": true
     },
     "is-callable": {
       "version": "1.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-callable/-/is-callable-1.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-callable/-/is-callable-1.2.0.tgz",
       "integrity": "sha1-gzNlYLVKOONeOi33r9BFTWkUaLs=",
       "dev": true
     },
     "is-ci": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-ci/-/is-ci-2.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-ci/-/is-ci-2.0.0.tgz",
       "integrity": "sha1-a8YzQYGBDgS1wis9WJ/cpVAmQEw=",
       "dev": true,
       "requires": {
@@ -6880,7 +6880,7 @@
     },
     "is-data-descriptor": {
       "version": "0.1.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
       "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "dev": true,
       "requires": {
@@ -6889,13 +6889,13 @@
       "dependencies": {
         "is-buffer": {
           "version": "1.1.6",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-buffer/-/is-buffer-1.1.6.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-buffer/-/is-buffer-1.1.6.tgz",
           "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
           "dev": true
         },
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
@@ -6906,13 +6906,13 @@
     },
     "is-date-object": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-date-object/-/is-date-object-1.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-date-object/-/is-date-object-1.0.2.tgz",
       "integrity": "sha1-vac28s2P0G0yhE53Q7+nSUw7/X4=",
       "dev": true
     },
     "is-descriptor": {
       "version": "0.1.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-descriptor/-/is-descriptor-0.1.6.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-descriptor/-/is-descriptor-0.1.6.tgz",
       "integrity": "sha1-Nm2CQN3kh8pRgjsaufB6EKeCUco=",
       "dev": true,
       "requires": {
@@ -6923,7 +6923,7 @@
       "dependencies": {
         "kind-of": {
           "version": "5.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/kind-of/-/kind-of-5.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/kind-of/-/kind-of-5.1.0.tgz",
           "integrity": "sha1-cpyR4thXt6QZofmqZWhcTDP1hF0=",
           "dev": true
         }
@@ -6931,19 +6931,19 @@
     },
     "is-docker": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-docker/-/is-docker-2.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-docker/-/is-docker-2.0.0.tgz",
       "integrity": "sha1-LLDfDnXi0GT+GGTDfN6st7Lc8ls=",
       "dev": true
     },
     "is-dotfile": {
       "version": "1.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-dotfile/-/is-dotfile-1.0.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-dotfile/-/is-dotfile-1.0.3.tgz",
       "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
       "dev": true
     },
     "is-equal-shallow": {
       "version": "0.1.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
       "dev": true,
       "requires": {
@@ -6952,25 +6952,25 @@
     },
     "is-extendable": {
       "version": "0.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-extendable/-/is-extendable-0.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-extendable/-/is-extendable-0.1.1.tgz",
       "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
       "dev": true
     },
     "is-extglob": {
       "version": "2.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-extglob/-/is-extglob-2.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
       "dev": true
     },
     "is-finite": {
       "version": "1.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-finite/-/is-finite-1.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-finite/-/is-finite-1.1.0.tgz",
       "integrity": "sha1-kEE1x3+0LAZB1qobzbxNqo2ggvM=",
       "dev": true
     },
     "is-fullwidth-code-point": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "dev": true,
       "requires": {
@@ -6979,13 +6979,13 @@
     },
     "is-generator-function": {
       "version": "1.0.7",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-generator-function/-/is-generator-function-1.0.7.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-generator-function/-/is-generator-function-1.0.7.tgz",
       "integrity": "sha1-0hMuUpuwAAp/gHlNS99c1eWBNSI=",
       "dev": true
     },
     "is-glob": {
       "version": "4.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-glob/-/is-glob-4.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-glob/-/is-glob-4.0.1.tgz",
       "integrity": "sha1-dWfb6fL14kZ7x3q4PEopSCQHpdw=",
       "dev": true,
       "requires": {
@@ -6994,7 +6994,7 @@
     },
     "is-installed-globally": {
       "version": "0.3.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-installed-globally/-/is-installed-globally-0.3.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-installed-globally/-/is-installed-globally-0.3.2.tgz",
       "integrity": "sha1-/T76ee5nDRGHIzGC1bCh3QAxMUE=",
       "dev": true,
       "requires": {
@@ -7004,25 +7004,25 @@
     },
     "is-npm": {
       "version": "4.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-npm/-/is-npm-4.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-npm/-/is-npm-4.0.0.tgz",
       "integrity": "sha1-yQ3YOAaW34enptgjwg0LErvjyE0=",
       "dev": true
     },
     "is-number": {
       "version": "7.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-number/-/is-number-7.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha1-dTU0W4lnNNX4DE0GxQlVUnoU8Ss=",
       "dev": true
     },
     "is-obj": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-obj/-/is-obj-2.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-obj/-/is-obj-2.0.0.tgz",
       "integrity": "sha1-Rz+wXZc3BeP9liBUUBjKjiLvSYI=",
       "dev": true
     },
     "is-observable": {
       "version": "1.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-observable/-/is-observable-1.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-observable/-/is-observable-1.1.0.tgz",
       "integrity": "sha1-s+mGyPRN6VCGfKtUA/WjRlAFl14=",
       "dev": true,
       "requires": {
@@ -7031,13 +7031,13 @@
     },
     "is-path-cwd": {
       "version": "2.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
       "integrity": "sha1-Z9Q7gmZKe1GR/ZEZEn6zAASKn9s=",
       "dev": true
     },
     "is-path-in-cwd": {
       "version": "2.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-path-in-cwd/-/is-path-in-cwd-2.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-path-in-cwd/-/is-path-in-cwd-2.1.0.tgz",
       "integrity": "sha1-v+Lcomxp85cmWkAJljYCk1oFOss=",
       "dev": true,
       "requires": {
@@ -7046,7 +7046,7 @@
       "dependencies": {
         "is-path-inside": {
           "version": "2.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-path-inside/-/is-path-inside-2.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-path-inside/-/is-path-inside-2.1.0.tgz",
           "integrity": "sha1-fJgQWH1lmkDSe8201WFuqwWUlLI=",
           "dev": true,
           "requires": {
@@ -7057,19 +7057,19 @@
     },
     "is-path-inside": {
       "version": "3.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-path-inside/-/is-path-inside-3.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-path-inside/-/is-path-inside-3.0.2.tgz",
       "integrity": "sha1-9SIPyCo+IzdXKR3dycWHfyofMBc=",
       "dev": true
     },
     "is-plain-obj": {
       "version": "1.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
       "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
       "dev": true
     },
     "is-plain-object": {
       "version": "2.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-plain-object/-/is-plain-object-2.0.4.tgz",
       "integrity": "sha1-LBY7P6+xtgbZ0Xko8FwqHDjgdnc=",
       "dev": true,
       "requires": {
@@ -7078,37 +7078,37 @@
     },
     "is-posix-bracket": {
       "version": "0.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
       "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
       "dev": true
     },
     "is-potential-custom-element-name": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.0.tgz",
       "integrity": "sha1-DFLlS8yjkbssSUsh6GJtczbG45c=",
       "dev": true
     },
     "is-primitive": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-primitive/-/is-primitive-2.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-primitive/-/is-primitive-2.0.0.tgz",
       "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
       "dev": true
     },
     "is-promise": {
       "version": "2.2.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-promise/-/is-promise-2.2.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-promise/-/is-promise-2.2.2.tgz",
       "integrity": "sha1-OauVnMv5p3TPB597QMeib3YxNfE=",
       "dev": true
     },
     "is-redirect": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-redirect/-/is-redirect-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-redirect/-/is-redirect-1.0.0.tgz",
       "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
       "dev": true
     },
     "is-regex": {
       "version": "1.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-regex/-/is-regex-1.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-regex/-/is-regex-1.1.0.tgz",
       "integrity": "sha1-7OOOOJ5JDfDcIcrqK9WW+Yf3Z/8=",
       "dev": true,
       "requires": {
@@ -7117,13 +7117,13 @@
     },
     "is-retry-allowed": {
       "version": "1.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
       "integrity": "sha1-13hIi9CkZmo76KFIK58rqv7eqLQ=",
       "dev": true
     },
     "is-scoped": {
       "version": "2.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-scoped/-/is-scoped-2.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-scoped/-/is-scoped-2.1.0.tgz",
       "integrity": "sha1-/vBxN3Jli99b7kGGCCZ92ubTVm0=",
       "dev": true,
       "requires": {
@@ -7132,19 +7132,19 @@
     },
     "is-stream": {
       "version": "1.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-stream/-/is-stream-1.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
       "dev": true
     },
     "is-subset": {
       "version": "0.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-subset/-/is-subset-0.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-subset/-/is-subset-0.1.1.tgz",
       "integrity": "sha1-ilkRfZMt4d4A8kX83TnOQ/HpOaY=",
       "dev": true
     },
     "is-symbol": {
       "version": "1.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-symbol/-/is-symbol-1.0.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-symbol/-/is-symbol-1.0.3.tgz",
       "integrity": "sha1-OOEBS55jKb4N6dJKQU/XRB7GGTc=",
       "dev": true,
       "requires": {
@@ -7153,7 +7153,7 @@
     },
     "is-typed-array": {
       "version": "1.1.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-typed-array/-/is-typed-array-1.1.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-typed-array/-/is-typed-array-1.1.3.tgz",
       "integrity": "sha1-pP9aXmcuGlX5nH9U5ZWXr1wd8E0=",
       "dev": true,
       "requires": {
@@ -7165,19 +7165,19 @@
     },
     "is-typedarray": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "dev": true
     },
     "is-url": {
       "version": "1.2.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-url/-/is-url-1.2.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-url/-/is-url-1.2.4.tgz",
       "integrity": "sha1-BKTfRtKMTP89c9Af8Gq+sxihqlI=",
       "dev": true
     },
     "is-url-superb": {
       "version": "3.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-url-superb/-/is-url-superb-3.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-url-superb/-/is-url-superb-3.0.0.tgz",
       "integrity": "sha1-uaHah4oaxzZZBH0eb07yLCCdPiU=",
       "dev": true,
       "requires": {
@@ -7186,25 +7186,25 @@
     },
     "is-utf8": {
       "version": "0.2.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-utf8/-/is-utf8-0.2.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-utf8/-/is-utf8-0.2.1.tgz",
       "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
       "dev": true
     },
     "is-valid-glob": {
       "version": "0.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-valid-glob/-/is-valid-glob-0.3.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-valid-glob/-/is-valid-glob-0.3.0.tgz",
       "integrity": "sha1-1LVcafUYhvm2XHDWwmItN+KfSP4=",
       "dev": true
     },
     "is-windows": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-windows/-/is-windows-1.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-windows/-/is-windows-1.0.2.tgz",
       "integrity": "sha1-0YUOuXkezRjmGCzhKjDzlmNLsZ0=",
       "dev": true
     },
     "is-wsl": {
       "version": "2.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-wsl/-/is-wsl-2.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-wsl/-/is-wsl-2.2.0.tgz",
       "integrity": "sha1-dKTHbnfKn9P5MvKQwX6jJs0VcnE=",
       "dev": true,
       "requires": {
@@ -7213,13 +7213,13 @@
     },
     "is-yarn-global": {
       "version": "0.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-yarn-global/-/is-yarn-global-0.3.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-yarn-global/-/is-yarn-global-0.3.0.tgz",
       "integrity": "sha1-1QLTOCWQ6jAEiTdGdUyJE5lz4jI=",
       "dev": true
     },
     "is2": {
       "version": "2.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is2/-/is2-2.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is2/-/is2-2.0.1.tgz",
       "integrity": "sha1-isNVZEhAkhzkNdlPBdOpRjTTSBo=",
       "dev": true,
       "requires": {
@@ -7230,43 +7230,43 @@
     },
     "isarray": {
       "version": "0.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/isarray/-/isarray-0.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/isarray/-/isarray-0.0.1.tgz",
       "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
       "dev": true
     },
     "isexe": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/isexe/-/isexe-2.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
     "isobject": {
       "version": "3.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/isobject/-/isobject-3.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
     },
     "isstream": {
       "version": "0.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/isstream/-/isstream-0.1.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
       "dev": true
     },
     "issue-regex": {
       "version": "3.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/issue-regex/-/issue-regex-3.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/issue-regex/-/issue-regex-3.1.0.tgz",
       "integrity": "sha1-BnHwlNZEnFtxL6w8lWKuy3J9cJ4=",
       "dev": true
     },
     "js-tokens": {
       "version": "4.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/js-tokens/-/js-tokens-4.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha1-GSA/tZmR35jjoocFDUZHzerzJJk=",
       "dev": true
     },
     "js-yaml": {
       "version": "3.14.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/js-yaml/-/js-yaml-3.14.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/js-yaml/-/js-yaml-3.14.0.tgz",
       "integrity": "sha1-p6NBcPJqIbsWJCTYray0ETpp5II=",
       "dev": true,
       "requires": {
@@ -7276,13 +7276,13 @@
     },
     "jsbn": {
       "version": "0.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/jsbn/-/jsbn-0.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
       "dev": true
     },
     "jsdom": {
       "version": "16.2.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/jsdom/-/jsdom-16.2.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/jsdom/-/jsdom-16.2.2.tgz",
       "integrity": "sha1-dvL3VBZGvrRqk49dxHa4hwW+3ys=",
       "dev": true,
       "requires": {
@@ -7316,7 +7316,7 @@
       "dependencies": {
         "tough-cookie": {
           "version": "3.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/tough-cookie/-/tough-cookie-3.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/tough-cookie/-/tough-cookie-3.0.1.tgz",
           "integrity": "sha1-nfT1fnOcJpMKAYGEiH9K233Kc7I=",
           "dev": true,
           "requires": {
@@ -7327,7 +7327,7 @@
         },
         "tr46": {
           "version": "2.0.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/tr46/-/tr46-2.0.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/tr46/-/tr46-2.0.2.tgz",
           "integrity": "sha1-Ayc1ht7xWVrgj+2zjXczzukdJHk=",
           "dev": true,
           "requires": {
@@ -7336,13 +7336,13 @@
         },
         "webidl-conversions": {
           "version": "6.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
           "integrity": "sha1-kRG01+qArNQPUnDWZmIa+ni2lRQ=",
           "dev": true
         },
         "whatwg-url": {
           "version": "8.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/whatwg-url/-/whatwg-url-8.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/whatwg-url/-/whatwg-url-8.1.0.tgz",
           "integrity": "sha1-xiis3PRbgidM5yge4x3TyDl5F3E=",
           "dev": true,
           "requires": {
@@ -7353,7 +7353,7 @@
           "dependencies": {
             "webidl-conversions": {
               "version": "5.0.0",
-              "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
+              "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
               "integrity": "sha1-rlnIoAsSFUOirMZcBDT1ew/BGv8=",
               "dev": true
             }
@@ -7363,55 +7363,55 @@
     },
     "jsesc": {
       "version": "2.5.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/jsesc/-/jsesc-2.5.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/jsesc/-/jsesc-2.5.2.tgz",
       "integrity": "sha1-gFZNLkg9rPbo7yCWUKZ98/DCg6Q=",
       "dev": true
     },
     "json-buffer": {
       "version": "3.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/json-buffer/-/json-buffer-3.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/json-buffer/-/json-buffer-3.0.0.tgz",
       "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=",
       "dev": true
     },
     "json-parse-better-errors": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
       "integrity": "sha1-u4Z8+zRQ5pEHwTHRxRS6s9yLyqk=",
       "dev": true
     },
     "json-schema": {
       "version": "0.2.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/json-schema/-/json-schema-0.2.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/json-schema/-/json-schema-0.2.3.tgz",
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
       "dev": true
     },
     "json-schema-traverse": {
       "version": "0.4.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA=",
       "dev": true
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
     },
     "json-stringify-safe": {
       "version": "5.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
     },
     "json3": {
       "version": "3.3.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/json3/-/json3-3.3.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/json3/-/json3-3.3.2.tgz",
       "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
       "dev": true
     },
     "json5": {
       "version": "2.1.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/json5/-/json5-2.1.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/json5/-/json5-2.1.3.tgz",
       "integrity": "sha1-ybD3+pIzv+WAf+ZvzzpWF+1ZfUM=",
       "dev": true,
       "requires": {
@@ -7420,13 +7420,13 @@
     },
     "jsonschema": {
       "version": "1.2.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/jsonschema/-/jsonschema-1.2.6.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/jsonschema/-/jsonschema-1.2.6.tgz",
       "integrity": "sha1-UrCo6dwGu65ylSSdA+S5+u6KDAs=",
       "dev": true
     },
     "jsprim": {
       "version": "1.4.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/jsprim/-/jsprim-1.4.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/jsprim/-/jsprim-1.4.1.tgz",
       "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
       "dev": true,
       "requires": {
@@ -7438,7 +7438,7 @@
     },
     "jszip": {
       "version": "3.4.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/jszip/-/jszip-3.4.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/jszip/-/jszip-3.4.0.tgz",
       "integrity": "sha1-GmlCH6Xwu5vCIqRryogYL7oHU1A=",
       "dev": true,
       "requires": {
@@ -7450,13 +7450,13 @@
     },
     "just-extend": {
       "version": "4.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/just-extend/-/just-extend-4.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/just-extend/-/just-extend-4.1.0.tgz",
       "integrity": "sha1-cnikAn2IlgFkDuDODloAuZJGfaQ=",
       "dev": true
     },
     "keyv": {
       "version": "3.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/keyv/-/keyv-3.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/keyv/-/keyv-3.1.0.tgz",
       "integrity": "sha1-7MIoSG9pmR5J6UdkhaW+Ho/FxNk=",
       "dev": true,
       "requires": {
@@ -7465,13 +7465,13 @@
     },
     "kind-of": {
       "version": "6.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/kind-of/-/kind-of-6.0.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/kind-of/-/kind-of-6.0.3.tgz",
       "integrity": "sha1-B8BQNKbDSfoG4k+jWqdttFgM5N0=",
       "dev": true
     },
     "kuler": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/kuler/-/kuler-1.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/kuler/-/kuler-1.0.1.tgz",
       "integrity": "sha1-73x4TzbJ+24W3TFQ0VJneysCKKY=",
       "dev": true,
       "requires": {
@@ -7480,7 +7480,7 @@
     },
     "latest-version": {
       "version": "5.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/latest-version/-/latest-version-5.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/latest-version/-/latest-version-5.1.0.tgz",
       "integrity": "sha1-EZ3+kI/jjRXfpD7NE/oS7Igy+s4=",
       "dev": true,
       "requires": {
@@ -7489,7 +7489,7 @@
     },
     "launchpad": {
       "version": "0.7.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/launchpad/-/launchpad-0.7.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/launchpad/-/launchpad-0.7.5.tgz",
       "integrity": "sha1-oWlQyTdXLxDvAcm+lFqW96745Cc=",
       "dev": true,
       "optional": true,
@@ -7506,7 +7506,7 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-2.6.9.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/debug/-/debug-2.6.9.tgz",
           "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
           "dev": true,
           "optional": true,
@@ -7516,7 +7516,7 @@
         },
         "rimraf": {
           "version": "3.0.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/rimraf/-/rimraf-3.0.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/rimraf/-/rimraf-3.0.2.tgz",
           "integrity": "sha1-8aVAK6YiCtUswSgrrBrjqkn9Bho=",
           "dev": true,
           "optional": true,
@@ -7528,7 +7528,7 @@
     },
     "lazystream": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lazystream/-/lazystream-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lazystream/-/lazystream-1.0.0.tgz",
       "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
       "dev": true,
       "requires": {
@@ -7546,7 +7546,7 @@
     },
     "levn": {
       "version": "0.4.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/levn/-/levn-0.4.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/levn/-/levn-0.4.1.tgz",
       "integrity": "sha1-rkViwAdHO5MqYgDUAyaN0v/8at4=",
       "dev": true,
       "requires": {
@@ -7556,7 +7556,7 @@
     },
     "lie": {
       "version": "3.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lie/-/lie-3.3.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lie/-/lie-3.3.0.tgz",
       "integrity": "sha1-3Pgt7lRfRgdNryAMfBxaCOD0D2o=",
       "dev": true,
       "requires": {
@@ -7565,18 +7565,18 @@
     },
     "lightercollective": {
       "version": "0.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lightercollective/-/lightercollective-0.3.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lightercollective/-/lightercollective-0.3.0.tgz",
       "integrity": "sha1-HwdjhkLsZF1wvbaasnd2dvNaKPA="
     },
     "lines-and-columns": {
       "version": "1.1.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
       "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
       "dev": true
     },
     "listr": {
       "version": "0.14.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/listr/-/listr-0.14.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/listr/-/listr-0.14.3.tgz",
       "integrity": "sha1-L+qQlgTkNL5GTFC926DUlpKPpYY=",
       "dev": true,
       "requires": {
@@ -7593,7 +7593,7 @@
       "dependencies": {
         "p-map": {
           "version": "2.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/p-map/-/p-map-2.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/p-map/-/p-map-2.1.0.tgz",
           "integrity": "sha1-MQko/u+cnsxltosXaTAYpmXOoXU=",
           "dev": true
         }
@@ -7601,7 +7601,7 @@
     },
     "listr-input": {
       "version": "0.2.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/listr-input/-/listr-input-0.2.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/listr-input/-/listr-input-0.2.1.tgz",
       "integrity": "sha1-znNcNFMGg1gDiP35Ri7P69O2YSY=",
       "dev": true,
       "requires": {
@@ -7613,13 +7613,13 @@
     },
     "listr-silent-renderer": {
       "version": "1.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz",
       "integrity": "sha1-kktaN1cVN3C/Go4/v3S4u/P5JC4=",
       "dev": true
     },
     "listr-update-renderer": {
       "version": "0.5.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/listr-update-renderer/-/listr-update-renderer-0.5.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/listr-update-renderer/-/listr-update-renderer-0.5.0.tgz",
       "integrity": "sha1-Tqg2hUinuK7LfgbYyVy0WuLt5qI=",
       "dev": true,
       "requires": {
@@ -7635,13 +7635,13 @@
       "dependencies": {
         "ansi-styles": {
           "version": "2.2.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-styles/-/ansi-styles-2.2.1.tgz",
           "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
           "dev": true
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -7654,7 +7654,7 @@
         },
         "figures": {
           "version": "1.7.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/figures/-/figures-1.7.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/figures/-/figures-1.7.0.tgz",
           "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
           "dev": true,
           "requires": {
@@ -7664,13 +7664,13 @@
         },
         "indent-string": {
           "version": "3.2.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/indent-string/-/indent-string-3.2.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/indent-string/-/indent-string-3.2.0.tgz",
           "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
           "dev": true
         },
         "log-symbols": {
           "version": "1.0.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/log-symbols/-/log-symbols-1.0.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/log-symbols/-/log-symbols-1.0.2.tgz",
           "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
           "dev": true,
           "requires": {
@@ -7679,7 +7679,7 @@
         },
         "supports-color": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/supports-color/-/supports-color-2.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/supports-color/-/supports-color-2.0.0.tgz",
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         }
@@ -7687,7 +7687,7 @@
     },
     "listr-verbose-renderer": {
       "version": "0.5.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/listr-verbose-renderer/-/listr-verbose-renderer-0.5.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/listr-verbose-renderer/-/listr-verbose-renderer-0.5.0.tgz",
       "integrity": "sha1-8RMhZ1NepMEmEQK58o2sfLoeA9s=",
       "dev": true,
       "requires": {
@@ -7699,7 +7699,7 @@
       "dependencies": {
         "chalk": {
           "version": "2.4.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/chalk/-/chalk-2.4.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
           "dev": true,
           "requires": {
@@ -7710,7 +7710,7 @@
         },
         "cli-cursor": {
           "version": "2.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cli-cursor/-/cli-cursor-2.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/cli-cursor/-/cli-cursor-2.1.0.tgz",
           "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
           "dev": true,
           "requires": {
@@ -7719,7 +7719,7 @@
         },
         "figures": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/figures/-/figures-2.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/figures/-/figures-2.0.0.tgz",
           "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
           "dev": true,
           "requires": {
@@ -7728,13 +7728,13 @@
         },
         "mimic-fn": {
           "version": "1.2.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mimic-fn/-/mimic-fn-1.2.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/mimic-fn/-/mimic-fn-1.2.0.tgz",
           "integrity": "sha1-ggyGo5M0ZA6ZUWkovQP8qIBX0CI=",
           "dev": true
         },
         "onetime": {
           "version": "2.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/onetime/-/onetime-2.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/onetime/-/onetime-2.0.1.tgz",
           "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
           "dev": true,
           "requires": {
@@ -7743,7 +7743,7 @@
         },
         "restore-cursor": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/restore-cursor/-/restore-cursor-2.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/restore-cursor/-/restore-cursor-2.0.0.tgz",
           "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
           "dev": true,
           "requires": {
@@ -7755,7 +7755,7 @@
     },
     "load-json-file": {
       "version": "1.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/load-json-file/-/load-json-file-1.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "dev": true,
       "requires": {
@@ -7768,7 +7768,7 @@
       "dependencies": {
         "pify": {
           "version": "2.3.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/pify/-/pify-2.3.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         }
@@ -7776,7 +7776,7 @@
     },
     "locate-path": {
       "version": "3.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/locate-path/-/locate-path-3.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/locate-path/-/locate-path-3.0.0.tgz",
       "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
       "dev": true,
       "requires": {
@@ -7786,13 +7786,13 @@
     },
     "lodash": {
       "version": "4.17.15",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash/-/lodash-4.17.15.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lodash/-/lodash-4.17.15.tgz",
       "integrity": "sha1-tEf2ZwoEVbv+7dETku/zMOoJdUg=",
       "dev": true
     },
     "lodash._baseassign": {
       "version": "3.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
       "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
       "dev": true,
       "requires": {
@@ -7802,43 +7802,43 @@
     },
     "lodash._basecopy": {
       "version": "3.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
       "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
       "dev": true
     },
     "lodash._basecreate": {
       "version": "3.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
       "integrity": "sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE=",
       "dev": true
     },
     "lodash._getnative": {
       "version": "3.9.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
       "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
       "dev": true
     },
     "lodash._isiterateecall": {
       "version": "3.0.9",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
       "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
       "dev": true
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
       "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
       "dev": true
     },
     "lodash.camelcase": {
       "version": "4.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
       "dev": true
     },
     "lodash.create": {
       "version": "3.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash.create/-/lodash.create-3.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lodash.create/-/lodash.create-3.1.1.tgz",
       "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
       "dev": true,
       "requires": {
@@ -7849,55 +7849,55 @@
     },
     "lodash.defaults": {
       "version": "4.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
       "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw=",
       "dev": true
     },
     "lodash.difference": {
       "version": "4.5.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash.difference/-/lodash.difference-4.5.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lodash.difference/-/lodash.difference-4.5.0.tgz",
       "integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw=",
       "dev": true
     },
     "lodash.flatten": {
       "version": "4.4.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
       "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=",
       "dev": true
     },
     "lodash.get": {
       "version": "4.4.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash.get/-/lodash.get-4.4.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
       "dev": true
     },
     "lodash.isarguments": {
       "version": "3.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
       "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
       "dev": true
     },
     "lodash.isarray": {
       "version": "3.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
       "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
       "dev": true
     },
     "lodash.isequal": {
       "version": "4.5.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
       "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
       "dev": true
     },
     "lodash.isplainobject": {
       "version": "4.0.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
       "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
       "dev": true
     },
     "lodash.keys": {
       "version": "3.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash.keys/-/lodash.keys-3.1.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lodash.keys/-/lodash.keys-3.1.2.tgz",
       "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
       "dev": true,
       "requires": {
@@ -7908,19 +7908,19 @@
     },
     "lodash.padend": {
       "version": "4.6.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash.padend/-/lodash.padend-4.6.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lodash.padend/-/lodash.padend-4.6.1.tgz",
       "integrity": "sha1-U8y6BH0G4VjTEfRdpiX05J5vFm4=",
       "dev": true
     },
     "lodash.sortby": {
       "version": "4.7.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
       "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
       "dev": true
     },
     "lodash.template": {
       "version": "4.5.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash.template/-/lodash.template-4.5.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lodash.template/-/lodash.template-4.5.0.tgz",
       "integrity": "sha1-+XYZXPPzR9DV9SSDVp/oAxzM6Ks=",
       "dev": true,
       "requires": {
@@ -7930,7 +7930,7 @@
     },
     "lodash.templatesettings": {
       "version": "4.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash.templatesettings/-/lodash.templatesettings-4.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lodash.templatesettings/-/lodash.templatesettings-4.2.0.tgz",
       "integrity": "sha1-5IExDwSdPPbUfpEq0JMTsVTw+zM=",
       "dev": true,
       "requires": {
@@ -7939,19 +7939,19 @@
     },
     "lodash.union": {
       "version": "4.6.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash.union/-/lodash.union-4.6.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lodash.union/-/lodash.union-4.6.0.tgz",
       "integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg=",
       "dev": true
     },
     "lodash.zip": {
       "version": "4.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash.zip/-/lodash.zip-4.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lodash.zip/-/lodash.zip-4.2.0.tgz",
       "integrity": "sha1-7GZi5IlkCO1KtsVCo5kLcswIACA=",
       "dev": true
     },
     "log-symbols": {
       "version": "3.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/log-symbols/-/log-symbols-3.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/log-symbols/-/log-symbols-3.0.0.tgz",
       "integrity": "sha1-86CFFqXeqJMzan3uFNGKHP2rd8Q=",
       "dev": true,
       "requires": {
@@ -7960,7 +7960,7 @@
       "dependencies": {
         "chalk": {
           "version": "2.4.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/chalk/-/chalk-2.4.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
           "dev": true,
           "requires": {
@@ -7973,7 +7973,7 @@
     },
     "log-update": {
       "version": "2.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/log-update/-/log-update-2.3.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/log-update/-/log-update-2.3.0.tgz",
       "integrity": "sha1-iDKP19HOeTiykoN0bwsbwSayRwg=",
       "dev": true,
       "requires": {
@@ -7984,19 +7984,19 @@
       "dependencies": {
         "ansi-escapes": {
           "version": "3.2.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
           "integrity": "sha1-h4C5j/nb9WOBUtHx/lwde0RCl2s=",
           "dev": true
         },
         "ansi-regex": {
           "version": "3.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
         "cli-cursor": {
           "version": "2.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cli-cursor/-/cli-cursor-2.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/cli-cursor/-/cli-cursor-2.1.0.tgz",
           "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
           "dev": true,
           "requires": {
@@ -8005,19 +8005,19 @@
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
         "mimic-fn": {
           "version": "1.2.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mimic-fn/-/mimic-fn-1.2.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/mimic-fn/-/mimic-fn-1.2.0.tgz",
           "integrity": "sha1-ggyGo5M0ZA6ZUWkovQP8qIBX0CI=",
           "dev": true
         },
         "onetime": {
           "version": "2.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/onetime/-/onetime-2.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/onetime/-/onetime-2.0.1.tgz",
           "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
           "dev": true,
           "requires": {
@@ -8026,7 +8026,7 @@
         },
         "restore-cursor": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/restore-cursor/-/restore-cursor-2.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/restore-cursor/-/restore-cursor-2.0.0.tgz",
           "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
           "dev": true,
           "requires": {
@@ -8036,7 +8036,7 @@
         },
         "string-width": {
           "version": "2.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string-width/-/string-width-2.1.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/string-width/-/string-width-2.1.1.tgz",
           "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
           "dev": true,
           "requires": {
@@ -8046,7 +8046,7 @@
         },
         "strip-ansi": {
           "version": "4.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
@@ -8055,7 +8055,7 @@
         },
         "wrap-ansi": {
           "version": "3.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/wrap-ansi/-/wrap-ansi-3.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/wrap-ansi/-/wrap-ansi-3.0.1.tgz",
           "integrity": "sha1-KIoE2H7aXChuBg3+jxNc6NAH+Lo=",
           "dev": true,
           "requires": {
@@ -8067,7 +8067,7 @@
     },
     "logform": {
       "version": "1.10.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/logform/-/logform-1.10.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/logform/-/logform-1.10.0.tgz",
       "integrity": "sha1-ydVZhxTJK1RuI/TngUfEDx4CAS4=",
       "dev": true,
       "requires": {
@@ -8080,7 +8080,7 @@
       "dependencies": {
         "ms": {
           "version": "2.1.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.1.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ms/-/ms-2.1.2.tgz",
           "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
           "dev": true
         }
@@ -8088,13 +8088,13 @@
     },
     "lolex": {
       "version": "1.3.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lolex/-/lolex-1.3.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lolex/-/lolex-1.3.2.tgz",
       "integrity": "sha1-fD2mL/yzDw9agKJWbKJORdigHzE=",
       "dev": true
     },
     "loose-envify": {
       "version": "1.4.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/loose-envify/-/loose-envify-1.4.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha1-ce5R+nvkyuwaY4OffmgtgTLTDK8=",
       "dev": true,
       "requires": {
@@ -8103,7 +8103,7 @@
     },
     "loud-rejection": {
       "version": "1.6.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/loud-rejection/-/loud-rejection-1.6.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/loud-rejection/-/loud-rejection-1.6.0.tgz",
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
       "dev": true,
       "requires": {
@@ -8113,19 +8113,19 @@
     },
     "lower-case": {
       "version": "1.1.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lower-case/-/lower-case-1.1.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lower-case/-/lower-case-1.1.4.tgz",
       "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw=",
       "dev": true
     },
     "lowercase-keys": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
       "integrity": "sha1-b54wtHCE2XGnyCD/FabFFnt0wm8=",
       "dev": true
     },
     "lru-cache": {
       "version": "5.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lru-cache/-/lru-cache-5.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lru-cache/-/lru-cache-5.1.1.tgz",
       "integrity": "sha1-HaJ+ZxAnGUdpXa9oSOhH8B2EuSA=",
       "dev": true,
       "requires": {
@@ -8134,13 +8134,13 @@
     },
     "luxon": {
       "version": "1.24.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/luxon/-/luxon-1.24.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/luxon/-/luxon-1.24.1.tgz",
       "integrity": "sha1-qDgyZhMe1OrtS19DD5bzaVQDpSo=",
       "dev": true
     },
     "magic-string": {
       "version": "0.22.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/magic-string/-/magic-string-0.22.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/magic-string/-/magic-string-0.22.5.tgz",
       "integrity": "sha1-jpz1r930Q4XB2lvCpqDb0QsDZX4=",
       "dev": true,
       "requires": {
@@ -8149,7 +8149,7 @@
     },
     "make-dir": {
       "version": "3.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/make-dir/-/make-dir-3.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/make-dir/-/make-dir-3.1.0.tgz",
       "integrity": "sha1-QV6WcEazp/HRhSd9hKpYIDcmoT8=",
       "dev": true,
       "requires": {
@@ -8158,7 +8158,7 @@
       "dependencies": {
         "semver": {
           "version": "6.3.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/semver/-/semver-6.3.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/semver/-/semver-6.3.0.tgz",
           "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0=",
           "dev": true
         }
@@ -8166,7 +8166,7 @@
     },
     "map-age-cleaner": {
       "version": "0.1.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
       "integrity": "sha1-fVg6cwZDTAVf5HSw9FB45uG0uSo=",
       "dev": true,
       "requires": {
@@ -8175,25 +8175,25 @@
     },
     "map-cache": {
       "version": "0.2.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/map-cache/-/map-cache-0.2.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/map-cache/-/map-cache-0.2.2.tgz",
       "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
       "dev": true
     },
     "map-obj": {
       "version": "4.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/map-obj/-/map-obj-4.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/map-obj/-/map-obj-4.1.0.tgz",
       "integrity": "sha1-uRIhtUJzS58UJWwBMsiXxdclb9U=",
       "dev": true
     },
     "map-stream": {
       "version": "0.0.7",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/map-stream/-/map-stream-0.0.7.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/map-stream/-/map-stream-0.0.7.tgz",
       "integrity": "sha1-ih8HiW2CsQkmvTdEokIACfiJdKg=",
       "dev": true
     },
     "map-visit": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/map-visit/-/map-visit-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/map-visit/-/map-visit-1.0.0.tgz",
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
       "dev": true,
       "requires": {
@@ -8202,7 +8202,7 @@
     },
     "matcher": {
       "version": "1.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/matcher/-/matcher-1.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/matcher/-/matcher-1.1.1.tgz",
       "integrity": "sha1-UdgwHhOPhAmCszixFrsMCa9iwcI=",
       "dev": true,
       "requires": {
@@ -8211,13 +8211,13 @@
     },
     "math-random": {
       "version": "1.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/math-random/-/math-random-1.0.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/math-random/-/math-random-1.0.4.tgz",
       "integrity": "sha1-XdaUPJOFSCZwFtTjTwV1gwgMUUw=",
       "dev": true
     },
     "md5": {
       "version": "2.2.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/md5/-/md5-2.2.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/md5/-/md5-2.2.1.tgz",
       "integrity": "sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=",
       "dev": true,
       "requires": {
@@ -8228,7 +8228,7 @@
       "dependencies": {
         "is-buffer": {
           "version": "1.1.6",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-buffer/-/is-buffer-1.1.6.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-buffer/-/is-buffer-1.1.6.tgz",
           "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
           "dev": true
         }
@@ -8236,13 +8236,13 @@
     },
     "media-typer": {
       "version": "0.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/media-typer/-/media-typer-0.3.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
       "dev": true
     },
     "mem": {
       "version": "4.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mem/-/mem-4.3.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/mem/-/mem-4.3.0.tgz",
       "integrity": "sha1-Rhr0l7xK4JYIzbLmDu+2m/90QXg=",
       "dev": true,
       "requires": {
@@ -8253,7 +8253,7 @@
     },
     "meow": {
       "version": "6.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/meow/-/meow-6.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/meow/-/meow-6.1.1.tgz",
       "integrity": "sha1-GtZMS3ayok37L2Nf3crfMg0lFGc=",
       "dev": true,
       "requires": {
@@ -8272,13 +8272,13 @@
       "dependencies": {
         "type-fest": {
           "version": "0.13.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/type-fest/-/type-fest-0.13.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/type-fest/-/type-fest-0.13.1.tgz",
           "integrity": "sha1-AXLLW86AsL1ULqNI21DH4hg02TQ=",
           "dev": true
         },
         "yargs-parser": {
           "version": "18.1.3",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/yargs-parser/-/yargs-parser-18.1.3.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/yargs-parser/-/yargs-parser-18.1.3.tgz",
           "integrity": "sha1-vmjEl1xrKr9GkjawyHA2L6sJp7A=",
           "dev": true,
           "requires": {
@@ -8290,37 +8290,37 @@
     },
     "merge-descriptors": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
       "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
       "dev": true
     },
     "merge-stream": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/merge-stream/-/merge-stream-2.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha1-UoI2KaFN0AyXcPtq1H3GMQ8sH2A=",
       "dev": true
     },
     "merge2": {
       "version": "1.4.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/merge2/-/merge2-1.4.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha1-Q2iJL4hekHRVpv19xVwMnUBJkK4=",
       "dev": true
     },
     "methods": {
       "version": "1.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/methods/-/methods-1.1.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/methods/-/methods-1.1.2.tgz",
       "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
       "dev": true
     },
     "microbuffer": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/microbuffer/-/microbuffer-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/microbuffer/-/microbuffer-1.0.0.tgz",
       "integrity": "sha1-izgy7UDIfVH0e7I0kTppinVtGdI=",
       "dev": true
     },
     "micromatch": {
       "version": "4.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/micromatch/-/micromatch-4.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/micromatch/-/micromatch-4.0.2.tgz",
       "integrity": "sha1-T8sJmb+fvC/L3SEvbWKbmlbDklk=",
       "dev": true,
       "requires": {
@@ -8330,19 +8330,19 @@
     },
     "mime": {
       "version": "1.6.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mime/-/mime-1.6.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/mime/-/mime-1.6.0.tgz",
       "integrity": "sha1-Ms2eXGRVO9WNGaVor0Uqz/BJgbE=",
       "dev": true
     },
     "mime-db": {
       "version": "1.44.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mime-db/-/mime-db-1.44.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/mime-db/-/mime-db-1.44.0.tgz",
       "integrity": "sha1-+hHF6wrKEzS0Izy01S8QxaYnL5I=",
       "dev": true
     },
     "mime-types": {
       "version": "2.1.27",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mime-types/-/mime-types-2.1.27.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/mime-types/-/mime-types-2.1.27.tgz",
       "integrity": "sha1-R5SfmOJ56lMRn1ci4PNOUpvsAJ8=",
       "dev": true,
       "requires": {
@@ -8351,25 +8351,25 @@
     },
     "mimic-fn": {
       "version": "2.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/mimic-fn/-/mimic-fn-2.1.0.tgz",
       "integrity": "sha1-ftLCzMyvhNP/y3pptXcR/CCDQBs=",
       "dev": true
     },
     "mimic-response": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mimic-response/-/mimic-response-1.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/mimic-response/-/mimic-response-1.0.1.tgz",
       "integrity": "sha1-SSNTiHju9CBjy4o+OweYeBSHqxs=",
       "dev": true
     },
     "min-indent": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/min-indent/-/min-indent-1.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/min-indent/-/min-indent-1.0.1.tgz",
       "integrity": "sha1-pj9oFnOzBXH76LwlaGrnRu76mGk=",
       "dev": true
     },
     "minify": {
       "version": "5.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/minify/-/minify-5.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/minify/-/minify-5.1.1.tgz",
       "integrity": "sha1-azYTYYWdOlYv9qCXrgZMILzLW0A=",
       "dev": true,
       "requires": {
@@ -8384,7 +8384,7 @@
       "dependencies": {
         "debug": {
           "version": "4.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-4.1.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/debug/-/debug-4.1.1.tgz",
           "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
           "dev": true,
           "requires": {
@@ -8393,7 +8393,7 @@
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.1.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ms/-/ms-2.1.2.tgz",
           "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
           "dev": true
         }
@@ -8401,13 +8401,13 @@
     },
     "minimalistic-assert": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
       "integrity": "sha1-LhlN4ERibUoQ5/f7wAznPoPk1cc=",
       "dev": true
     },
     "minimatch": {
       "version": "3.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/minimatch/-/minimatch-3.0.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
       "dev": true,
       "requires": {
@@ -8416,7 +8416,7 @@
     },
     "minimatch-all": {
       "version": "1.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/minimatch-all/-/minimatch-all-1.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/minimatch-all/-/minimatch-all-1.1.0.tgz",
       "integrity": "sha1-QMSWonouEo0Zv3WOdrsBoMcUV4c=",
       "dev": true,
       "requires": {
@@ -8425,13 +8425,13 @@
     },
     "minimist": {
       "version": "1.2.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/minimist/-/minimist-1.2.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/minimist/-/minimist-1.2.5.tgz",
       "integrity": "sha1-Z9ZgFLZqaoqqDAg8X9WN9OTpdgI=",
       "dev": true
     },
     "minimist-options": {
       "version": "4.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/minimist-options/-/minimist-options-4.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/minimist-options/-/minimist-options-4.1.0.tgz",
       "integrity": "sha1-wGVXE8U6ii69d/+iR9NCxA8BBhk=",
       "dev": true,
       "requires": {
@@ -8442,7 +8442,7 @@
     },
     "minipass": {
       "version": "2.9.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/minipass/-/minipass-2.9.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/minipass/-/minipass-2.9.0.tgz",
       "integrity": "sha1-5xN2Ln0+Mv7YAxFc+T4EvKn8yaY=",
       "dev": true,
       "requires": {
@@ -8452,7 +8452,7 @@
     },
     "minizlib": {
       "version": "1.3.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/minizlib/-/minizlib-1.3.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/minizlib/-/minizlib-1.3.3.tgz",
       "integrity": "sha1-IpDeloGKNMKVUcio0wEha9Zahh0=",
       "dev": true,
       "requires": {
@@ -8461,7 +8461,7 @@
     },
     "mixin-deep": {
       "version": "1.3.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mixin-deep/-/mixin-deep-1.3.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/mixin-deep/-/mixin-deep-1.3.2.tgz",
       "integrity": "sha1-ESC0PcNZp4Xc5ltVuC4lfM9HlWY=",
       "dev": true,
       "requires": {
@@ -8471,7 +8471,7 @@
       "dependencies": {
         "is-extendable": {
           "version": "1.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-extendable/-/is-extendable-1.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-extendable/-/is-extendable-1.0.1.tgz",
           "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
           "dev": true,
           "requires": {
@@ -8482,7 +8482,7 @@
     },
     "mkdirp": {
       "version": "0.5.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mkdirp/-/mkdirp-0.5.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/mkdirp/-/mkdirp-0.5.5.tgz",
       "integrity": "sha1-2Rzv1i0UNsoPQWIOJRKI1CAJne8=",
       "dev": true,
       "requires": {
@@ -8491,7 +8491,7 @@
     },
     "mocha": {
       "version": "7.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mocha/-/mocha-7.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/mocha/-/mocha-7.2.0.tgz",
       "integrity": "sha1-AcwiewDYdase7QOnUQZonP7VpgQ=",
       "dev": true,
       "requires": {
@@ -8523,13 +8523,13 @@
       "dependencies": {
         "ansi-regex": {
           "version": "4.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-4.1.0.tgz",
           "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc=",
           "dev": true
         },
         "debug": {
           "version": "3.2.6",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-3.2.6.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/debug/-/debug-3.2.6.tgz",
           "integrity": "sha1-6D0X3hbYp++3cX7b5fsQE17uYps=",
           "dev": true,
           "requires": {
@@ -8538,13 +8538,13 @@
         },
         "emoji-regex": {
           "version": "7.0.3",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/emoji-regex/-/emoji-regex-7.0.3.tgz",
           "integrity": "sha1-kzoEBShgyF6DwSJHnEdIqOTHIVY=",
           "dev": true
         },
         "glob": {
           "version": "7.1.3",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/glob/-/glob-7.1.3.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/glob/-/glob-7.1.3.tgz",
           "integrity": "sha1-OWCDLT8VdBCDQtr9OmezMsCWnfE=",
           "dev": true,
           "requires": {
@@ -8558,13 +8558,13 @@
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
         "js-yaml": {
           "version": "3.13.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/js-yaml/-/js-yaml-3.13.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/js-yaml/-/js-yaml-3.13.1.tgz",
           "integrity": "sha1-r/FRswv9+o5J4F2iLnQV6d+jeEc=",
           "dev": true,
           "requires": {
@@ -8574,13 +8574,13 @@
         },
         "ms": {
           "version": "2.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.1.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ms/-/ms-2.1.1.tgz",
           "integrity": "sha1-MKWGTrPrsKZvLr5tcnrwagnYbgo=",
           "dev": true
         },
         "string-width": {
           "version": "3.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string-width/-/string-width-3.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/string-width/-/string-width-3.1.0.tgz",
           "integrity": "sha1-InZ74htirxCBV0MG9prFG2IgOWE=",
           "dev": true,
           "requires": {
@@ -8591,7 +8591,7 @@
         },
         "strip-ansi": {
           "version": "5.2.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
           "dev": true,
           "requires": {
@@ -8600,13 +8600,13 @@
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
           "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "dev": true
         },
         "supports-color": {
           "version": "6.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/supports-color/-/supports-color-6.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/supports-color/-/supports-color-6.0.0.tgz",
           "integrity": "sha1-ds/nQs8fQbubHCmtAwaMBbTA5Ao=",
           "dev": true,
           "requires": {
@@ -8615,7 +8615,7 @@
         },
         "yargs": {
           "version": "13.3.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/yargs/-/yargs-13.3.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/yargs/-/yargs-13.3.2.tgz",
           "integrity": "sha1-rX/+/sGqWVZayRX4Lcyzipwxot0=",
           "dev": true,
           "requires": {
@@ -8635,19 +8635,19 @@
     },
     "mout": {
       "version": "1.2.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mout/-/mout-1.2.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/mout/-/mout-1.2.2.tgz",
       "integrity": "sha1-ybcYpJmAagYyzt4XjoD0NiWed30=",
       "dev": true
     },
     "ms": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
     "multer": {
       "version": "1.4.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/multer/-/multer-1.4.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/multer/-/multer-1.4.2.tgz",
       "integrity": "sha1-Lx9NEtuu66dMs35iPyNL9NPSBXo=",
       "dev": true,
       "requires": {
@@ -8663,13 +8663,13 @@
     },
     "multi-clamp": {
       "version": "1.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/multi-clamp/-/multi-clamp-1.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/multi-clamp/-/multi-clamp-1.1.0.tgz",
       "integrity": "sha1-nQeOMJYXSi+5CGp7fPGdFcNBWGI=",
       "dev": true
     },
     "multipipe": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/multipipe/-/multipipe-1.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/multipipe/-/multipipe-1.0.2.tgz",
       "integrity": "sha1-zBPv2DPJzamfIk+GhGG44aP9k50=",
       "dev": true,
       "requires": {
@@ -8679,13 +8679,13 @@
     },
     "mute-stream": {
       "version": "0.0.8",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mute-stream/-/mute-stream-0.0.8.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/mute-stream/-/mute-stream-0.0.8.tgz",
       "integrity": "sha1-FjDEKyJR/4HiooPelqVJfqkuXg0=",
       "dev": true
     },
     "mz": {
       "version": "2.7.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mz/-/mz-2.7.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/mz/-/mz-2.7.0.tgz",
       "integrity": "sha1-lQCAV6Vsr63CvGPd5/n/aVWUjjI=",
       "dev": true,
       "requires": {
@@ -8696,13 +8696,13 @@
     },
     "nan": {
       "version": "2.14.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/nan/-/nan-2.14.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/nan/-/nan-2.14.1.tgz",
       "integrity": "sha1-174036MQW5FJTDFHCJMV7/iHSwE=",
       "dev": true
     },
     "nanomatch": {
       "version": "1.2.13",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/nanomatch/-/nanomatch-1.2.13.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/nanomatch/-/nanomatch-1.2.13.tgz",
       "integrity": "sha1-uHqKpPwN6P5r6IiVs4mD/yZb0Rk=",
       "dev": true,
       "requires": {
@@ -8721,19 +8721,19 @@
     },
     "native-promise-only": {
       "version": "0.8.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/native-promise-only/-/native-promise-only-0.8.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/native-promise-only/-/native-promise-only-0.8.1.tgz",
       "integrity": "sha1-IKMYwwy0X3H+et+/eyHJnBRy7xE=",
       "dev": true
     },
     "natural-compare": {
       "version": "1.4.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/natural-compare/-/natural-compare-1.4.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
     "neatequal": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/neatequal/-/neatequal-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/neatequal/-/neatequal-1.0.0.tgz",
       "integrity": "sha1-LuEhG8n6bkxVcV/SELsFYC6xrjs=",
       "dev": true,
       "requires": {
@@ -8742,19 +8742,19 @@
     },
     "negotiator": {
       "version": "0.6.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/negotiator/-/negotiator-0.6.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/negotiator/-/negotiator-0.6.2.tgz",
       "integrity": "sha1-/qz3zPUlp3rpY0Q2pkiD/+yjRvs=",
       "dev": true
     },
     "neo-async": {
       "version": "2.6.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/neo-async/-/neo-async-2.6.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/neo-async/-/neo-async-2.6.1.tgz",
       "integrity": "sha1-rCetpmFn+ohJpq3dg39rGJrSCBw=",
       "dev": true
     },
     "new-github-release-url": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/new-github-release-url/-/new-github-release-url-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/new-github-release-url/-/new-github-release-url-1.0.0.tgz",
       "integrity": "sha1-SThH5v7M45wkfp2Jkpvnc9Ln93c=",
       "dev": true,
       "requires": {
@@ -8763,7 +8763,7 @@
       "dependencies": {
         "type-fest": {
           "version": "0.4.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/type-fest/-/type-fest-0.4.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/type-fest/-/type-fest-0.4.1.tgz",
           "integrity": "sha1-i993dDOF2KTxO6lfYQ9czWjHKPg=",
           "dev": true
         }
@@ -8771,13 +8771,13 @@
     },
     "nice-try": {
       "version": "1.0.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/nice-try/-/nice-try-1.0.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha1-ozeKdpbOfSI+iPybdkvX7xCJ42Y=",
       "dev": true
     },
     "nise": {
       "version": "4.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/nise/-/nise-4.0.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/nise/-/nise-4.0.3.tgz",
       "integrity": "sha1-n3n/AvoALtX/vFOK1YUY+gEdyRM=",
       "dev": true,
       "requires": {
@@ -8790,7 +8790,7 @@
       "dependencies": {
         "path-to-regexp": {
           "version": "1.8.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
           "integrity": "sha1-iHs7qdhDk+h6CgufTLdWGYtTVIo=",
           "dev": true,
           "requires": {
@@ -8801,7 +8801,7 @@
     },
     "no-case": {
       "version": "2.3.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/no-case/-/no-case-2.3.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/no-case/-/no-case-2.3.2.tgz",
       "integrity": "sha1-YLgTOWvjmz8SiKTB7V0efSi0ZKw=",
       "dev": true,
       "requires": {
@@ -8810,7 +8810,7 @@
     },
     "node-environment-flags": {
       "version": "1.0.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/node-environment-flags/-/node-environment-flags-1.0.6.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/node-environment-flags/-/node-environment-flags-1.0.6.tgz",
       "integrity": "sha1-owrBNiH299Z0JgpU3t4EjDmCwIg=",
       "dev": true,
       "requires": {
@@ -8820,7 +8820,7 @@
       "dependencies": {
         "semver": {
           "version": "5.7.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/semver/-/semver-5.7.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/semver/-/semver-5.7.1.tgz",
           "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc=",
           "dev": true
         }
@@ -8828,7 +8828,7 @@
     },
     "node-gyp": {
       "version": "3.8.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/node-gyp/-/node-gyp-3.8.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/node-gyp/-/node-gyp-3.8.0.tgz",
       "integrity": "sha1-VAMEJhwzDoDQ1e3OJTpoyzlkIYw=",
       "dev": true,
       "requires": {
@@ -8848,13 +8848,13 @@
     },
     "node-status-codes": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/node-status-codes/-/node-status-codes-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/node-status-codes/-/node-status-codes-1.0.0.tgz",
       "integrity": "sha1-WuVUHQJGRdMqWPzdyc7s6nrjrC8=",
       "dev": true
     },
     "nomnom": {
       "version": "1.8.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/nomnom/-/nomnom-1.8.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/nomnom/-/nomnom-1.8.1.tgz",
       "integrity": "sha1-IVH3Ikcrp55Qp2/BJbuMjy5Nwqc=",
       "dev": true,
       "requires": {
@@ -8864,13 +8864,13 @@
       "dependencies": {
         "ansi-styles": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-styles/-/ansi-styles-1.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-styles/-/ansi-styles-1.0.0.tgz",
           "integrity": "sha1-yxAt8cVvUSPquLZ817mAJ6AnkXg=",
           "dev": true
         },
         "chalk": {
           "version": "0.4.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/chalk/-/chalk-0.4.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/chalk/-/chalk-0.4.0.tgz",
           "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
           "dev": true,
           "requires": {
@@ -8881,13 +8881,13 @@
         },
         "strip-ansi": {
           "version": "0.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-0.1.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-0.1.1.tgz",
           "integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE=",
           "dev": true
         },
         "underscore": {
           "version": "1.6.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/underscore/-/underscore-1.6.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/underscore/-/underscore-1.6.0.tgz",
           "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
           "dev": true
         }
@@ -8895,7 +8895,7 @@
     },
     "nopt": {
       "version": "3.0.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/nopt/-/nopt-3.0.6.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/nopt/-/nopt-3.0.6.tgz",
       "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
       "dev": true,
       "requires": {
@@ -8904,7 +8904,7 @@
     },
     "normalize-package-data": {
       "version": "2.5.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
       "integrity": "sha1-5m2xg4sgDB38IzIl0SyzZSDiNKg=",
       "dev": true,
       "requires": {
@@ -8916,7 +8916,7 @@
       "dependencies": {
         "hosted-git-info": {
           "version": "2.8.8",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
           "integrity": "sha1-dTm9S8Hg4KiVgVouAmJCCxKFhIg=",
           "dev": true
         }
@@ -8924,13 +8924,13 @@
     },
     "normalize-path": {
       "version": "3.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/normalize-path/-/normalize-path-3.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha1-Dc1p/yOhybEf0JeDFmRKA4ghamU=",
       "dev": true
     },
     "normalize-url": {
       "version": "4.5.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/normalize-url/-/normalize-url-4.5.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/normalize-url/-/normalize-url-4.5.0.tgz",
       "integrity": "sha1-RTNUCH5sqWlXvY9br3U/WYIUISk=",
       "dev": true
     },
@@ -9094,7 +9094,7 @@
     },
     "npm-name": {
       "version": "5.5.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/npm-name/-/npm-name-5.5.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/npm-name/-/npm-name-5.5.0.tgz",
       "integrity": "sha1-OnOtvLBIikGkT/gg7VHcwyxyvQk=",
       "dev": true,
       "requires": {
@@ -9109,7 +9109,7 @@
       "dependencies": {
         "get-stream": {
           "version": "4.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/get-stream/-/get-stream-4.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/get-stream/-/get-stream-4.1.0.tgz",
           "integrity": "sha1-wbJVV189wh1Zv8ec09K0axw6VLU=",
           "dev": true,
           "requires": {
@@ -9118,7 +9118,7 @@
         },
         "got": {
           "version": "9.6.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/got/-/got-9.6.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/got/-/got-9.6.0.tgz",
           "integrity": "sha1-7fRefWf5lUVwXeH3u+7rEhdl7YU=",
           "dev": true,
           "requires": {
@@ -9137,13 +9137,13 @@
         },
         "prepend-http": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/prepend-http/-/prepend-http-2.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/prepend-http/-/prepend-http-2.0.0.tgz",
           "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
           "dev": true
         },
         "url-parse-lax": {
           "version": "3.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
           "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
           "dev": true,
           "requires": {
@@ -9154,7 +9154,7 @@
     },
     "npm-run-path": {
       "version": "4.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/npm-run-path/-/npm-run-path-4.0.1.tgz",
       "integrity": "sha1-t+zR5e1T2o43pV4cImnguX7XSOo=",
       "dev": true,
       "requires": {
@@ -9163,7 +9163,7 @@
     },
     "npmlog": {
       "version": "4.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/npmlog/-/npmlog-4.1.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/npmlog/-/npmlog-4.1.2.tgz",
       "integrity": "sha1-CKfyqL9zRgR3mp76StXMcXq7lUs=",
       "dev": true,
       "requires": {
@@ -9175,37 +9175,37 @@
     },
     "number-is-nan": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "dev": true
     },
     "nwsapi": {
       "version": "2.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/nwsapi/-/nwsapi-2.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/nwsapi/-/nwsapi-2.2.0.tgz",
       "integrity": "sha1-IEh5qePQaP8qVROcLHcngGgaOLc=",
       "dev": true
     },
     "oauth-sign": {
       "version": "0.9.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/oauth-sign/-/oauth-sign-0.9.0.tgz",
       "integrity": "sha1-R6ewFrqmi1+g7PPe4IqFxnmsZFU=",
       "dev": true
     },
     "object-assign": {
       "version": "4.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/object-assign/-/object-assign-4.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "dev": true
     },
     "object-component": {
       "version": "0.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/object-component/-/object-component-0.0.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/object-component/-/object-component-0.0.3.tgz",
       "integrity": "sha1-8MaapQ78lbhmwYb0AKM3acsvEpE=",
       "dev": true
     },
     "object-copy": {
       "version": "0.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/object-copy/-/object-copy-0.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/object-copy/-/object-copy-0.1.0.tgz",
       "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
       "dev": true,
       "requires": {
@@ -9216,7 +9216,7 @@
       "dependencies": {
         "define-property": {
           "version": "0.2.5",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/define-property/-/define-property-0.2.5.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
@@ -9225,13 +9225,13 @@
         },
         "is-buffer": {
           "version": "1.1.6",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-buffer/-/is-buffer-1.1.6.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-buffer/-/is-buffer-1.1.6.tgz",
           "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
           "dev": true
         },
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
@@ -9242,19 +9242,19 @@
     },
     "object-inspect": {
       "version": "1.7.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/object-inspect/-/object-inspect-1.7.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/object-inspect/-/object-inspect-1.7.0.tgz",
       "integrity": "sha1-9Pa9GBrXfwBrXs5gvQtvOY/3Smc=",
       "dev": true
     },
     "object-keys": {
       "version": "1.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/object-keys/-/object-keys-1.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha1-HEfyct8nfzsdrwYWd9nILiMixg4=",
       "dev": true
     },
     "object-visit": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/object-visit/-/object-visit-1.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/object-visit/-/object-visit-1.0.1.tgz",
       "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
       "dev": true,
       "requires": {
@@ -9263,7 +9263,7 @@
     },
     "object.assign": {
       "version": "4.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/object.assign/-/object.assign-4.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/object.assign/-/object.assign-4.1.0.tgz",
       "integrity": "sha1-lovxEA15Vrs8oIbwBvhGs7xACNo=",
       "dev": true,
       "requires": {
@@ -9275,7 +9275,7 @@
     },
     "object.getownpropertydescriptors": {
       "version": "2.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.0.tgz",
       "integrity": "sha1-Npvx+VktiridcS3O1cuBx8U1Jkk=",
       "dev": true,
       "requires": {
@@ -9285,7 +9285,7 @@
     },
     "object.omit": {
       "version": "2.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/object.omit/-/object.omit-2.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/object.omit/-/object.omit-2.0.1.tgz",
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
       "dev": true,
       "requires": {
@@ -9295,7 +9295,7 @@
     },
     "object.pick": {
       "version": "1.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/object.pick/-/object.pick-1.3.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/object.pick/-/object.pick-1.3.0.tgz",
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
       "dev": true,
       "requires": {
@@ -9304,13 +9304,13 @@
     },
     "obuf": {
       "version": "1.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/obuf/-/obuf-1.1.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/obuf/-/obuf-1.1.2.tgz",
       "integrity": "sha1-Cb6jND1BhZ69RGKS0RydTbYZCE4=",
       "dev": true
     },
     "on-finished": {
       "version": "2.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/on-finished/-/on-finished-2.3.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/on-finished/-/on-finished-2.3.0.tgz",
       "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
       "dev": true,
       "requires": {
@@ -9319,13 +9319,13 @@
     },
     "on-headers": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/on-headers/-/on-headers-1.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/on-headers/-/on-headers-1.0.2.tgz",
       "integrity": "sha1-dysK5qqlJcOZ5Imt+tkMQD6zwo8=",
       "dev": true
     },
     "once": {
       "version": "1.4.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/once/-/once-1.4.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
@@ -9334,13 +9334,13 @@
     },
     "one-time": {
       "version": "0.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/one-time/-/one-time-0.0.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/one-time/-/one-time-0.0.4.tgz",
       "integrity": "sha1-+M33eISCb+Tf+T46nMN7HkSAdC4=",
       "dev": true
     },
     "onetime": {
       "version": "5.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/onetime/-/onetime-5.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/onetime/-/onetime-5.1.0.tgz",
       "integrity": "sha1-//DzyRYX/mK7UBiWNumayKbfe+U=",
       "dev": true,
       "requires": {
@@ -9349,7 +9349,7 @@
     },
     "open": {
       "version": "7.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/open/-/open-7.0.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/open/-/open-7.0.4.tgz",
       "integrity": "sha1-woqdMV5cmDQL+Xn9yy5YZkqhDYM=",
       "dev": true,
       "requires": {
@@ -9359,13 +9359,13 @@
     },
     "opener": {
       "version": "1.5.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/opener/-/opener-1.5.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/opener/-/opener-1.5.1.tgz",
       "integrity": "sha1-bS8Od/GgrwAyrKcWwsH7uOfoq+0=",
       "dev": true
     },
     "opn": {
       "version": "3.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/opn/-/opn-3.0.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/opn/-/opn-3.0.3.tgz",
       "integrity": "sha1-ttmec5n3jWXDuq/+8fsojpuFJDo=",
       "dev": true,
       "requires": {
@@ -9374,7 +9374,7 @@
     },
     "optionator": {
       "version": "0.9.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/optionator/-/optionator-0.9.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/optionator/-/optionator-0.9.1.tgz",
       "integrity": "sha1-TyNqY3Pa4FZqbUPhMmZ09QwpFJk=",
       "dev": true,
       "requires": {
@@ -9388,7 +9388,7 @@
     },
     "ordered-read-streams": {
       "version": "0.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
       "integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
       "dev": true,
       "requires": {
@@ -9398,7 +9398,7 @@
     },
     "os-homedir": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/os-homedir/-/os-homedir-1.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true
     },
@@ -9490,13 +9490,13 @@
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
     "osenv": {
       "version": "0.1.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/osenv/-/osenv-0.1.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/osenv/-/osenv-0.1.5.tgz",
       "integrity": "sha1-hc36+uso6Gd/QW4odZK18/SepBA=",
       "dev": true,
       "requires": {
@@ -9506,7 +9506,7 @@
     },
     "ow": {
       "version": "0.15.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ow/-/ow-0.15.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ow/-/ow-0.15.1.tgz",
       "integrity": "sha1-rSG7TUxG1EeLlIUi42shT28TA50=",
       "dev": true,
       "requires": {
@@ -9515,31 +9515,31 @@
     },
     "p-cancelable": {
       "version": "1.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/p-cancelable/-/p-cancelable-1.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/p-cancelable/-/p-cancelable-1.1.0.tgz",
       "integrity": "sha1-0HjRWjr0CSIMiG8dmgyi5EGrJsw=",
       "dev": true
     },
     "p-defer": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/p-defer/-/p-defer-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/p-defer/-/p-defer-1.0.0.tgz",
       "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
       "dev": true
     },
     "p-finally": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/p-finally/-/p-finally-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/p-finally/-/p-finally-1.0.0.tgz",
       "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
       "dev": true
     },
     "p-is-promise": {
       "version": "2.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/p-is-promise/-/p-is-promise-2.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/p-is-promise/-/p-is-promise-2.1.0.tgz",
       "integrity": "sha1-kYzrrqJIpiz3/6uOO8qMX4gvxC4=",
       "dev": true
     },
     "p-limit": {
       "version": "2.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/p-limit/-/p-limit-2.3.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/p-limit/-/p-limit-2.3.0.tgz",
       "integrity": "sha1-PdM8ZHohT9//2DWTPrCG2g3CHbE=",
       "dev": true,
       "requires": {
@@ -9548,7 +9548,7 @@
     },
     "p-locate": {
       "version": "3.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/p-locate/-/p-locate-3.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/p-locate/-/p-locate-3.0.0.tgz",
       "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
       "dev": true,
       "requires": {
@@ -9557,7 +9557,7 @@
     },
     "p-map": {
       "version": "3.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/p-map/-/p-map-3.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/p-map/-/p-map-3.0.0.tgz",
       "integrity": "sha1-1wTZr4orpoTiYA2aIVmD1BQal50=",
       "dev": true,
       "requires": {
@@ -9566,7 +9566,7 @@
     },
     "p-memoize": {
       "version": "3.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/p-memoize/-/p-memoize-3.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/p-memoize/-/p-memoize-3.1.0.tgz",
       "integrity": "sha1-rHWHmDyeUwE5+WnKe0HvQOk2Wao=",
       "dev": true,
       "requires": {
@@ -9576,7 +9576,7 @@
     },
     "p-timeout": {
       "version": "3.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/p-timeout/-/p-timeout-3.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/p-timeout/-/p-timeout-3.2.0.tgz",
       "integrity": "sha1-x+F6vJcdKnli74NiazXWNazyPf4=",
       "dev": true,
       "requires": {
@@ -9585,13 +9585,13 @@
     },
     "p-try": {
       "version": "2.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/p-try/-/p-try-2.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY=",
       "dev": true
     },
     "package-json": {
       "version": "6.5.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/package-json/-/package-json-6.5.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/package-json/-/package-json-6.5.0.tgz",
       "integrity": "sha1-b+7ayjXnVyWHbQsOZJdGl/7RRbA=",
       "dev": true,
       "requires": {
@@ -9603,7 +9603,7 @@
       "dependencies": {
         "get-stream": {
           "version": "4.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/get-stream/-/get-stream-4.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/get-stream/-/get-stream-4.1.0.tgz",
           "integrity": "sha1-wbJVV189wh1Zv8ec09K0axw6VLU=",
           "dev": true,
           "requires": {
@@ -9612,7 +9612,7 @@
         },
         "got": {
           "version": "9.6.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/got/-/got-9.6.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/got/-/got-9.6.0.tgz",
           "integrity": "sha1-7fRefWf5lUVwXeH3u+7rEhdl7YU=",
           "dev": true,
           "requires": {
@@ -9631,19 +9631,19 @@
         },
         "prepend-http": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/prepend-http/-/prepend-http-2.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/prepend-http/-/prepend-http-2.0.0.tgz",
           "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
           "dev": true
         },
         "semver": {
           "version": "6.3.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/semver/-/semver-6.3.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/semver/-/semver-6.3.0.tgz",
           "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0=",
           "dev": true
         },
         "url-parse-lax": {
           "version": "3.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
           "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
           "dev": true,
           "requires": {
@@ -9654,13 +9654,13 @@
     },
     "pako": {
       "version": "1.0.11",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/pako/-/pako-1.0.11.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/pako/-/pako-1.0.11.tgz",
       "integrity": "sha1-bJWZ00DVTf05RjgCUqNXBaa5kr8=",
       "dev": true
     },
     "param-case": {
       "version": "2.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/param-case/-/param-case-2.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/param-case/-/param-case-2.1.1.tgz",
       "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
       "dev": true,
       "requires": {
@@ -9669,7 +9669,7 @@
     },
     "parent-module": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/parent-module/-/parent-module-1.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/parent-module/-/parent-module-1.0.1.tgz",
       "integrity": "sha1-aR0nCeeMefrjoVZiJFLQB2LKqqI=",
       "dev": true,
       "requires": {
@@ -9678,7 +9678,7 @@
     },
     "parse-glob": {
       "version": "3.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/parse-glob/-/parse-glob-3.0.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/parse-glob/-/parse-glob-3.0.4.tgz",
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
       "dev": true,
       "requires": {
@@ -9690,13 +9690,13 @@
       "dependencies": {
         "is-extglob": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-extglob/-/is-extglob-1.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-extglob/-/is-extglob-1.0.0.tgz",
           "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
           "dev": true
         },
         "is-glob": {
           "version": "2.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-glob/-/is-glob-2.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-glob/-/is-glob-2.0.1.tgz",
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
           "requires": {
@@ -9707,7 +9707,7 @@
     },
     "parse-json": {
       "version": "2.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/parse-json/-/parse-json-2.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/parse-json/-/parse-json-2.2.0.tgz",
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "dev": true,
       "requires": {
@@ -9716,19 +9716,19 @@
     },
     "parse-passwd": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/parse-passwd/-/parse-passwd-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/parse-passwd/-/parse-passwd-1.0.0.tgz",
       "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
       "dev": true
     },
     "parse5": {
       "version": "5.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/parse5/-/parse5-5.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/parse5/-/parse5-5.1.1.tgz",
       "integrity": "sha1-9o5OW6GFKsLK3AD0VV//bCq7YXg=",
       "dev": true
     },
     "parseqs": {
       "version": "0.0.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/parseqs/-/parseqs-0.0.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/parseqs/-/parseqs-0.0.5.tgz",
       "integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
       "dev": true,
       "requires": {
@@ -9737,7 +9737,7 @@
     },
     "parseuri": {
       "version": "0.0.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/parseuri/-/parseuri-0.0.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/parseuri/-/parseuri-0.0.5.tgz",
       "integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
       "dev": true,
       "requires": {
@@ -9746,73 +9746,73 @@
     },
     "parseurl": {
       "version": "1.3.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/parseurl/-/parseurl-1.3.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha1-naGee+6NEt/wUT7Vt2lXeTvC6NQ=",
       "dev": true
     },
     "pascalcase": {
       "version": "0.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/pascalcase/-/pascalcase-0.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/pascalcase/-/pascalcase-0.1.1.tgz",
       "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
       "dev": true
     },
     "path-dirname": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/path-dirname/-/path-dirname-1.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/path-dirname/-/path-dirname-1.0.2.tgz",
       "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
       "dev": true
     },
     "path-exists": {
       "version": "3.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/path-exists/-/path-exists-3.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/path-exists/-/path-exists-3.0.0.tgz",
       "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
       "dev": true
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
     "path-is-inside": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/path-is-inside/-/path-is-inside-1.0.2.tgz",
       "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
       "dev": true
     },
     "path-key": {
       "version": "3.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/path-key/-/path-key-3.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha1-WB9q3mWMu6ZaDTOA3ndTKVBU83U=",
       "dev": true
     },
     "path-parse": {
       "version": "1.0.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/path-parse/-/path-parse-1.0.6.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/path-parse/-/path-parse-1.0.6.tgz",
       "integrity": "sha1-1i27VnlAXXLEc37FhgDp3c8G0kw=",
       "dev": true
     },
     "path-to-regexp": {
       "version": "2.4.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/path-to-regexp/-/path-to-regexp-2.4.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/path-to-regexp/-/path-to-regexp-2.4.0.tgz",
       "integrity": "sha1-Nc5/Mz1WFvHB4b/iZsOrouWy5wQ=",
       "dev": true
     },
     "path-type": {
       "version": "4.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/path-type/-/path-type-4.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/path-type/-/path-type-4.0.0.tgz",
       "integrity": "sha1-hO0BwKe6OAr+CdkKjBgNzZ0DBDs=",
       "dev": true
     },
     "pathval": {
       "version": "1.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/pathval/-/pathval-1.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/pathval/-/pathval-1.1.0.tgz",
       "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
       "dev": true
     },
     "pause-stream": {
       "version": "0.0.11",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/pause-stream/-/pause-stream-0.0.11.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/pause-stream/-/pause-stream-0.0.11.tgz",
       "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
       "dev": true,
       "requires": {
@@ -9821,7 +9821,7 @@
     },
     "pem": {
       "version": "1.14.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/pem/-/pem-1.14.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/pem/-/pem-1.14.4.tgz",
       "integrity": "sha1-poxwxudRzMWztbzXr3iwrsEXf/k=",
       "dev": true,
       "requires": {
@@ -9833,13 +9833,13 @@
       "dependencies": {
         "es6-promisify": {
           "version": "6.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/es6-promisify/-/es6-promisify-6.1.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/es6-promisify/-/es6-promisify-6.1.1.tgz",
           "integrity": "sha1-RoN2Ubewa/b/+JPQPyk5NmjQFiE=",
           "dev": true
         },
         "which": {
           "version": "2.0.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/which/-/which-2.0.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/which/-/which-2.0.2.tgz",
           "integrity": "sha1-fGqN0KY2oDJ+ELWckobu6T8/UbE=",
           "dev": true,
           "requires": {
@@ -9850,37 +9850,37 @@
     },
     "pend": {
       "version": "1.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/pend/-/pend-1.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/pend/-/pend-1.2.0.tgz",
       "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
       "dev": true
     },
     "performance-now": {
       "version": "2.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/performance-now/-/performance-now-2.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
       "dev": true
     },
     "picomatch": {
       "version": "2.2.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/picomatch/-/picomatch-2.2.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/picomatch/-/picomatch-2.2.2.tgz",
       "integrity": "sha1-IfMz6ba46v8CRo9RRupAbTRfTa0=",
       "dev": true
     },
     "pify": {
       "version": "4.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/pify/-/pify-4.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/pify/-/pify-4.0.1.tgz",
       "integrity": "sha1-SyzSXFDVmHNcUCkiJP2MbfQeMjE=",
       "dev": true
     },
     "pinkie": {
       "version": "2.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/pinkie/-/pinkie-2.0.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/pinkie/-/pinkie-2.0.4.tgz",
       "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
       "dev": true
     },
     "pinkie-promise": {
       "version": "2.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
@@ -9889,7 +9889,7 @@
     },
     "pkg-dir": {
       "version": "4.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/pkg-dir/-/pkg-dir-4.2.0.tgz",
       "integrity": "sha1-8JkTPfft5CLoHR2ESCcO6z5CYfM=",
       "dev": true,
       "requires": {
@@ -9898,7 +9898,7 @@
       "dependencies": {
         "find-up": {
           "version": "4.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/find-up/-/find-up-4.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/find-up/-/find-up-4.1.0.tgz",
           "integrity": "sha1-l6/n1s3AvFkoWEt8jXsW6KmqXRk=",
           "dev": true,
           "requires": {
@@ -9908,7 +9908,7 @@
         },
         "locate-path": {
           "version": "5.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/locate-path/-/locate-path-5.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/locate-path/-/locate-path-5.0.0.tgz",
           "integrity": "sha1-Gvujlq/WdqbUJQTQpno6frn2KqA=",
           "dev": true,
           "requires": {
@@ -9917,7 +9917,7 @@
         },
         "p-locate": {
           "version": "4.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/p-locate/-/p-locate-4.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/p-locate/-/p-locate-4.1.0.tgz",
           "integrity": "sha1-o0KLtwiLOmApL2aRkni3wpetTwc=",
           "dev": true,
           "requires": {
@@ -9926,7 +9926,7 @@
         },
         "path-exists": {
           "version": "4.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/path-exists/-/path-exists-4.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/path-exists/-/path-exists-4.0.0.tgz",
           "integrity": "sha1-UTvb4tO5XXdi6METfvoZXGxhtbM=",
           "dev": true
         }
@@ -9934,7 +9934,7 @@
     },
     "plist": {
       "version": "2.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/plist/-/plist-2.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/plist/-/plist-2.1.0.tgz",
       "integrity": "sha1-V8zbeggh3yGDEhejytVOPhRqECU=",
       "dev": true,
       "optional": true,
@@ -9946,7 +9946,7 @@
     },
     "plylog": {
       "version": "1.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/plylog/-/plylog-1.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/plylog/-/plylog-1.1.0.tgz",
       "integrity": "sha1-9vNU4q4LAfbbTtER9LOFXanDdBc=",
       "dev": true,
       "requires": {
@@ -9957,7 +9957,7 @@
     },
     "polymer-analyzer": {
       "version": "3.2.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/polymer-analyzer/-/polymer-analyzer-3.2.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/polymer-analyzer/-/polymer-analyzer-3.2.4.tgz",
       "integrity": "sha1-fXY1ZiCiMo6LyeMORwaflykmDKE=",
       "dev": true,
       "requires": {
@@ -10002,13 +10002,13 @@
       "dependencies": {
         "ansi-styles": {
           "version": "2.2.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-styles/-/ansi-styles-2.2.1.tgz",
           "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
           "dev": true
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -10021,7 +10021,7 @@
         },
         "doctrine": {
           "version": "2.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/doctrine/-/doctrine-2.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/doctrine/-/doctrine-2.1.0.tgz",
           "integrity": "sha1-XNAfwQFiG0LEzX9dGmYkNxbT850=",
           "dev": true,
           "requires": {
@@ -10030,19 +10030,19 @@
         },
         "parse5": {
           "version": "4.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/parse5/-/parse5-4.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/parse5/-/parse5-4.0.0.tgz",
           "integrity": "sha1-bXhlbj2o14tOwLkG98CO8d/j9gg=",
           "dev": true
         },
         "strip-indent": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-indent/-/strip-indent-2.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/strip-indent/-/strip-indent-2.0.0.tgz",
           "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
           "dev": true
         },
         "supports-color": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/supports-color/-/supports-color-2.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/supports-color/-/supports-color-2.0.0.tgz",
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         }
@@ -10050,7 +10050,7 @@
     },
     "polymer-build": {
       "version": "3.1.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/polymer-build/-/polymer-build-3.1.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/polymer-build/-/polymer-build-3.1.4.tgz",
       "integrity": "sha1-q1OfGhPYA1GLE7c//QkZhDHZgUI=",
       "dev": true,
       "requires": {
@@ -10123,7 +10123,7 @@
       "dependencies": {
         "@types/mz": {
           "version": "0.0.31",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/mz/-/mz-0.0.31.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/mz/-/mz-0.0.31.tgz",
           "integrity": "sha1-pNgMCC/v5x5Ap8DwfR5lVbu8e1I=",
           "dev": true,
           "requires": {
@@ -10132,7 +10132,7 @@
         },
         "@types/resolve": {
           "version": "0.0.7",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/resolve/-/resolve-0.0.7.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/resolve/-/resolve-0.0.7.tgz",
           "integrity": "sha1-spnBO+jXErG1AvsUoIQlKs74T00=",
           "dev": true,
           "requires": {
@@ -10141,13 +10141,13 @@
         },
         "commander": {
           "version": "2.17.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/commander/-/commander-2.17.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/commander/-/commander-2.17.1.tgz",
           "integrity": "sha1-vXerfebelCBc6sxy8XFtKfIKd78=",
           "dev": true
         },
         "html-minifier": {
           "version": "3.5.21",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/html-minifier/-/html-minifier-3.5.21.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/html-minifier/-/html-minifier-3.5.21.tgz",
           "integrity": "sha1-0AQOBUcw41TbAIRjWTGUAVIS0gw=",
           "dev": true,
           "requires": {
@@ -10162,13 +10162,13 @@
         },
         "parse5": {
           "version": "4.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/parse5/-/parse5-4.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/parse5/-/parse5-4.0.0.tgz",
           "integrity": "sha1-bXhlbj2o14tOwLkG98CO8d/j9gg=",
           "dev": true
         },
         "uglify-js": {
           "version": "3.4.10",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/uglify-js/-/uglify-js-3.4.10.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/uglify-js/-/uglify-js-3.4.10.tgz",
           "integrity": "sha1-mtlWPY6zrN+404WX0q8dgV9qdV8=",
           "dev": true,
           "requires": {
@@ -10178,7 +10178,7 @@
           "dependencies": {
             "commander": {
               "version": "2.19.0",
-              "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/commander/-/commander-2.19.0.tgz",
+              "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/commander/-/commander-2.19.0.tgz",
               "integrity": "sha1-9hmKqE5bg8RgVLlN3tv+1e6f8So=",
               "dev": true
             }
@@ -10188,7 +10188,7 @@
     },
     "polymer-bundler": {
       "version": "4.0.10",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/polymer-bundler/-/polymer-bundler-4.0.10.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/polymer-bundler/-/polymer-bundler-4.0.10.tgz",
       "integrity": "sha1-q8jTOXdlLwMQaNA0yBBIQegNTLs=",
       "dev": true,
       "requires": {
@@ -10213,13 +10213,13 @@
       "dependencies": {
         "acorn": {
           "version": "5.7.4",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/acorn/-/acorn-5.7.4.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/acorn/-/acorn-5.7.4.tgz",
           "integrity": "sha1-Po2KmUfQWZoXltECJddDL0pKz14=",
           "dev": true
         },
         "acorn-jsx": {
           "version": "3.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
           "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
           "dev": true,
           "requires": {
@@ -10228,7 +10228,7 @@
           "dependencies": {
             "acorn": {
               "version": "3.3.0",
-              "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/acorn/-/acorn-3.3.0.tgz",
+              "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/acorn/-/acorn-3.3.0.tgz",
               "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
               "dev": true
             }
@@ -10236,7 +10236,7 @@
         },
         "espree": {
           "version": "3.5.4",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/espree/-/espree-3.5.4.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/espree/-/espree-3.5.4.tgz",
           "integrity": "sha1-sPRHGHyKi+2US4FaZgvd9d610ac=",
           "dev": true,
           "requires": {
@@ -10246,13 +10246,13 @@
         },
         "parse5": {
           "version": "4.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/parse5/-/parse5-4.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/parse5/-/parse5-4.0.0.tgz",
           "integrity": "sha1-bXhlbj2o14tOwLkG98CO8d/j9gg=",
           "dev": true
         },
         "source-map": {
           "version": "0.5.7",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "dev": true
         }
@@ -10260,7 +10260,7 @@
     },
     "polymer-project-config": {
       "version": "4.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/polymer-project-config/-/polymer-project-config-4.0.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/polymer-project-config/-/polymer-project-config-4.0.3.tgz",
       "integrity": "sha1-7wwaZ2zkgJkHmGyOkQdFZg3oAk8=",
       "dev": true,
       "requires": {
@@ -10274,7 +10274,7 @@
     },
     "polyserve": {
       "version": "0.27.15",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/polyserve/-/polyserve-0.27.15.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/polyserve/-/polyserve-0.27.15.tgz",
       "integrity": "sha1-Jh+loIc8jZX9cGhZj0TJ2sIM+cQ=",
       "dev": true,
       "requires": {
@@ -10316,7 +10316,7 @@
       "dependencies": {
         "lru-cache": {
           "version": "4.1.5",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lru-cache/-/lru-cache-4.1.5.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lru-cache/-/lru-cache-4.1.5.tgz",
           "integrity": "sha1-i75Q6oW+1ZvJ4z3KuCNe6bz0Q80=",
           "dev": true,
           "requires": {
@@ -10326,13 +10326,13 @@
         },
         "mime": {
           "version": "2.4.6",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mime/-/mime-2.4.6.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/mime/-/mime-2.4.6.tgz",
           "integrity": "sha1-5bQHyQ20QvK+tbFiNz0Htpr/pNE=",
           "dev": true
         },
         "yallist": {
           "version": "2.1.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/yallist/-/yallist-2.1.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/yallist/-/yallist-2.1.2.tgz",
           "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
           "dev": true
         }
@@ -10340,7 +10340,7 @@
     },
     "portfinder": {
       "version": "1.0.26",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/portfinder/-/portfinder-1.0.26.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/portfinder/-/portfinder-1.0.26.tgz",
       "integrity": "sha1-R1ZY1WyjC+1yrH8TeO01C9G2TnA=",
       "dev": true,
       "requires": {
@@ -10351,7 +10351,7 @@
       "dependencies": {
         "debug": {
           "version": "3.2.6",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-3.2.6.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/debug/-/debug-3.2.6.tgz",
           "integrity": "sha1-6D0X3hbYp++3cX7b5fsQE17uYps=",
           "dev": true,
           "requires": {
@@ -10360,7 +10360,7 @@
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.1.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ms/-/ms-2.1.2.tgz",
           "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
           "dev": true
         }
@@ -10368,37 +10368,37 @@
     },
     "posix-character-classes": {
       "version": "0.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
       "dev": true
     },
     "prelude-ls": {
       "version": "1.2.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha1-3rxkidem5rDnYRiIzsiAM30xY5Y=",
       "dev": true
     },
     "prepend-http": {
       "version": "1.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/prepend-http/-/prepend-http-1.0.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/prepend-http/-/prepend-http-1.0.4.tgz",
       "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
       "dev": true
     },
     "preserve": {
       "version": "0.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/preserve/-/preserve-0.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/preserve/-/preserve-0.2.0.tgz",
       "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
       "dev": true
     },
     "pretty-bytes": {
       "version": "4.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/pretty-bytes/-/pretty-bytes-4.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/pretty-bytes/-/pretty-bytes-4.0.2.tgz",
       "integrity": "sha1-sr+C5zUNZcbDOqlaqlpPYyf2HNk=",
       "dev": true
     },
     "prismjs": {
       "version": "1.20.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/prismjs/-/prismjs-1.20.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/prismjs/-/prismjs-1.20.0.tgz",
       "integrity": "sha1-m2hfxICjUU7nGY6sajv1AkMZ/wM=",
       "dev": true,
       "requires": {
@@ -10407,31 +10407,31 @@
     },
     "private": {
       "version": "0.1.8",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/private/-/private-0.1.8.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/private/-/private-0.1.8.tgz",
       "integrity": "sha1-I4Hts2ifelPWUxkAYPz4ItLzaP8=",
       "dev": true
     },
     "process-nextick-args": {
       "version": "2.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha1-eCDZsWEgzFXKmud5JoCufbptf+I=",
       "dev": true
     },
     "progress": {
       "version": "2.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/progress/-/progress-2.0.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/progress/-/progress-2.0.3.tgz",
       "integrity": "sha1-foz42PW48jnBvGi+tOt4Vn1XLvg=",
       "dev": true
     },
     "promise-polyfill": {
       "version": "7.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/promise-polyfill/-/promise-polyfill-7.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/promise-polyfill/-/promise-polyfill-7.0.0.tgz",
       "integrity": "sha1-xmW22h+X4hw/L3qgVDyQIJEnyxU=",
       "dev": true
     },
     "proxy-addr": {
       "version": "2.0.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/proxy-addr/-/proxy-addr-2.0.6.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/proxy-addr/-/proxy-addr-2.0.6.tgz",
       "integrity": "sha1-/cIzZQVEfT8vLGOO0nLK9hS7sr8=",
       "dev": true,
       "requires": {
@@ -10441,19 +10441,19 @@
     },
     "pseudomap": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/pseudomap/-/pseudomap-1.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/pseudomap/-/pseudomap-1.0.2.tgz",
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
       "dev": true
     },
     "psl": {
       "version": "1.8.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/psl/-/psl-1.8.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/psl/-/psl-1.8.0.tgz",
       "integrity": "sha1-kyb4vPsBOtzABf3/BWrM4CDlHCQ=",
       "dev": true
     },
     "pump": {
       "version": "3.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/pump/-/pump-3.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/pump/-/pump-3.0.0.tgz",
       "integrity": "sha1-tKIRaBW94vTh6mAjVOjHVWUQemQ=",
       "dev": true,
       "requires": {
@@ -10463,13 +10463,13 @@
     },
     "punycode": {
       "version": "2.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/punycode/-/punycode-2.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha1-tYsBCsQMIsVldhbI0sLALHv0eew=",
       "dev": true
     },
     "pupa": {
       "version": "2.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/pupa/-/pupa-2.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/pupa/-/pupa-2.0.1.tgz",
       "integrity": "sha1-29yf9I/76komoGm2+fersFEAhyY=",
       "dev": true,
       "requires": {
@@ -10478,7 +10478,7 @@
       "dependencies": {
         "escape-goat": {
           "version": "2.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/escape-goat/-/escape-goat-2.1.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/escape-goat/-/escape-goat-2.1.1.tgz",
           "integrity": "sha1-Gy3HcANnbEV+x2Cy3GjttkgYhnU=",
           "dev": true
         }
@@ -10486,31 +10486,31 @@
     },
     "q": {
       "version": "1.5.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/q/-/q-1.5.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/q/-/q-1.5.1.tgz",
       "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
       "dev": true
     },
     "qs": {
       "version": "6.5.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/qs/-/qs-6.5.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/qs/-/qs-6.5.2.tgz",
       "integrity": "sha1-yzroBuh0BERYTvFUzo7pjUA/PjY=",
       "dev": true
     },
     "querystring": {
       "version": "0.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/querystring/-/querystring-0.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/querystring/-/querystring-0.2.0.tgz",
       "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
       "dev": true
     },
     "quick-lru": {
       "version": "4.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/quick-lru/-/quick-lru-4.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/quick-lru/-/quick-lru-4.0.1.tgz",
       "integrity": "sha1-W4h48ROlgheEjGSCAmxz4bpXcn8=",
       "dev": true
     },
     "randomatic": {
       "version": "3.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/randomatic/-/randomatic-3.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/randomatic/-/randomatic-3.1.1.tgz",
       "integrity": "sha1-t3bvxZN1mE42xTey9RofCv8Noe0=",
       "dev": true,
       "requires": {
@@ -10521,7 +10521,7 @@
       "dependencies": {
         "is-number": {
           "version": "4.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-number/-/is-number-4.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-number/-/is-number-4.0.0.tgz",
           "integrity": "sha1-ACbjf1RU1z41bf5lZGmYZ8an8P8=",
           "dev": true
         }
@@ -10529,13 +10529,13 @@
     },
     "range-parser": {
       "version": "1.2.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/range-parser/-/range-parser-1.2.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/range-parser/-/range-parser-1.2.1.tgz",
       "integrity": "sha1-PPNwI9GZ4cJNGlW4SADC8+ZGgDE=",
       "dev": true
     },
     "raw-body": {
       "version": "2.4.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/raw-body/-/raw-body-2.4.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/raw-body/-/raw-body-2.4.0.tgz",
       "integrity": "sha1-oc5vucm8NWylLoklarWQWeE9AzI=",
       "dev": true,
       "requires": {
@@ -10547,7 +10547,7 @@
     },
     "rc": {
       "version": "1.2.8",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/rc/-/rc-1.2.8.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/rc/-/rc-1.2.8.tgz",
       "integrity": "sha1-zZJL9SAKB1uDwYjNa54hG3/A0+0=",
       "dev": true,
       "requires": {
@@ -10559,7 +10559,7 @@
       "dependencies": {
         "strip-json-comments": {
           "version": "2.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
           "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "dev": true
         }
@@ -10567,7 +10567,7 @@
     },
     "read-all-stream": {
       "version": "3.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/read-all-stream/-/read-all-stream-3.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/read-all-stream/-/read-all-stream-3.1.0.tgz",
       "integrity": "sha1-NcPhd/IHjveJ7kv6+kNzB06u9Po=",
       "dev": true,
       "requires": {
@@ -10577,7 +10577,7 @@
     },
     "read-pkg": {
       "version": "5.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/read-pkg/-/read-pkg-5.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/read-pkg/-/read-pkg-5.2.0.tgz",
       "integrity": "sha1-e/KVQ4yloz5WzTDgU7NO5yUMk8w=",
       "dev": true,
       "requires": {
@@ -10589,7 +10589,7 @@
       "dependencies": {
         "parse-json": {
           "version": "5.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/parse-json/-/parse-json-5.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/parse-json/-/parse-json-5.0.0.tgz",
           "integrity": "sha1-c+URTJhtFD76NxLU6iTbmkJm9g8=",
           "dev": true,
           "requires": {
@@ -10601,7 +10601,7 @@
         },
         "type-fest": {
           "version": "0.6.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/type-fest/-/type-fest-0.6.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/type-fest/-/type-fest-0.6.0.tgz",
           "integrity": "sha1-jSojcNPfiG61yQraHFv2GIrPg4s=",
           "dev": true
         }
@@ -10609,7 +10609,7 @@
     },
     "read-pkg-up": {
       "version": "7.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
       "integrity": "sha1-86YTV1hFlzOuK5VjgFbhhU5+9Qc=",
       "dev": true,
       "requires": {
@@ -10620,7 +10620,7 @@
       "dependencies": {
         "find-up": {
           "version": "4.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/find-up/-/find-up-4.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/find-up/-/find-up-4.1.0.tgz",
           "integrity": "sha1-l6/n1s3AvFkoWEt8jXsW6KmqXRk=",
           "dev": true,
           "requires": {
@@ -10630,7 +10630,7 @@
         },
         "locate-path": {
           "version": "5.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/locate-path/-/locate-path-5.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/locate-path/-/locate-path-5.0.0.tgz",
           "integrity": "sha1-Gvujlq/WdqbUJQTQpno6frn2KqA=",
           "dev": true,
           "requires": {
@@ -10639,7 +10639,7 @@
         },
         "p-locate": {
           "version": "4.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/p-locate/-/p-locate-4.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/p-locate/-/p-locate-4.1.0.tgz",
           "integrity": "sha1-o0KLtwiLOmApL2aRkni3wpetTwc=",
           "dev": true,
           "requires": {
@@ -10648,7 +10648,7 @@
         },
         "path-exists": {
           "version": "4.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/path-exists/-/path-exists-4.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/path-exists/-/path-exists-4.0.0.tgz",
           "integrity": "sha1-UTvb4tO5XXdi6METfvoZXGxhtbM=",
           "dev": true
         }
@@ -10656,7 +10656,7 @@
     },
     "readable-stream": {
       "version": "2.3.7",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/readable-stream/-/readable-stream-2.3.7.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/readable-stream/-/readable-stream-2.3.7.tgz",
       "integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
       "dev": true,
       "requires": {
@@ -10671,13 +10671,13 @@
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/isarray/-/isarray-1.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string_decoder/-/string_decoder-1.1.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
           "dev": true,
           "requires": {
@@ -10688,7 +10688,7 @@
     },
     "readdirp": {
       "version": "3.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/readdirp/-/readdirp-3.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/readdirp/-/readdirp-3.2.0.tgz",
       "integrity": "sha1-wwwzNSsSyW37S4lUIaSf1alZODk=",
       "dev": true,
       "requires": {
@@ -10697,7 +10697,7 @@
     },
     "redent": {
       "version": "3.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/redent/-/redent-3.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/redent/-/redent-3.0.0.tgz",
       "integrity": "sha1-5Ve3mYMWu1PJ8fVvpiY1LGljBZ8=",
       "dev": true,
       "requires": {
@@ -10707,7 +10707,7 @@
     },
     "reduce-flatten": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/reduce-flatten/-/reduce-flatten-1.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/reduce-flatten/-/reduce-flatten-1.0.1.tgz",
       "integrity": "sha1-JYx479FT3fk8tWEjf2EYTzaW4yc=",
       "dev": true
     },
@@ -10719,7 +10719,7 @@
     },
     "regenerate-unicode-properties": {
       "version": "8.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/regenerate-unicode-properties/-/regenerate-unicode-properties-8.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/regenerate-unicode-properties/-/regenerate-unicode-properties-8.2.0.tgz",
       "integrity": "sha1-5d5xEdZV57pgwFfb6f83yH5lzew=",
       "dev": true,
       "requires": {
@@ -10728,13 +10728,13 @@
     },
     "regenerator-runtime": {
       "version": "0.11.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
       "integrity": "sha1-vgWtf5v30i4Fb5cmzuUBf78Z4uk=",
       "dev": true
     },
     "regenerator-transform": {
       "version": "0.14.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/regenerator-transform/-/regenerator-transform-0.14.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/regenerator-transform/-/regenerator-transform-0.14.4.tgz",
       "integrity": "sha1-UmaFeJZRjRYWp4oEeTN6MOqXTMc=",
       "dev": true,
       "requires": {
@@ -10744,7 +10744,7 @@
     },
     "regex-cache": {
       "version": "0.4.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/regex-cache/-/regex-cache-0.4.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/regex-cache/-/regex-cache-0.4.4.tgz",
       "integrity": "sha1-db3FiioUls7EihKDW8VMjVYjNt0=",
       "dev": true,
       "requires": {
@@ -10753,7 +10753,7 @@
     },
     "regex-not": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/regex-not/-/regex-not-1.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/regex-not/-/regex-not-1.0.2.tgz",
       "integrity": "sha1-H07OJ+ALC2XgJHpoEOaoXYOldSw=",
       "dev": true,
       "requires": {
@@ -10763,13 +10763,13 @@
     },
     "regexpp": {
       "version": "3.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/regexpp/-/regexpp-3.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/regexpp/-/regexpp-3.1.0.tgz",
       "integrity": "sha1-IG0K0KVkjP+9uK5GQ489xRyfeOI=",
       "dev": true
     },
     "regexpu-core": {
       "version": "4.7.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/regexpu-core/-/regexpu-core-4.7.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/regexpu-core/-/regexpu-core-4.7.0.tgz",
       "integrity": "sha1-/L9FjFBDGwu3tF1pZ7gZLZHz2Tg=",
       "dev": true,
       "requires": {
@@ -10783,7 +10783,7 @@
     },
     "registry-auth-token": {
       "version": "4.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/registry-auth-token/-/registry-auth-token-4.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/registry-auth-token/-/registry-auth-token-4.1.1.tgz",
       "integrity": "sha1-QKM74eglOUYPlDKLD38PhMFtlHk=",
       "dev": true,
       "requires": {
@@ -10792,7 +10792,7 @@
     },
     "registry-url": {
       "version": "5.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/registry-url/-/registry-url-5.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/registry-url/-/registry-url-5.1.0.tgz",
       "integrity": "sha1-6YM0tQ1UNLgRNrROxjjZwgCcUAk=",
       "dev": true,
       "requires": {
@@ -10801,13 +10801,13 @@
     },
     "regjsgen": {
       "version": "0.5.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/regjsgen/-/regjsgen-0.5.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/regjsgen/-/regjsgen-0.5.2.tgz",
       "integrity": "sha1-kv8pX7He7L9uzaslQ9IH6RqjNzM=",
       "dev": true
     },
     "regjsparser": {
       "version": "0.6.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/regjsparser/-/regjsparser-0.6.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/regjsparser/-/regjsparser-0.6.4.tgz",
       "integrity": "sha1-p2n4aEMIQBpm6bUp0kNv9NBmYnI=",
       "dev": true,
       "requires": {
@@ -10816,7 +10816,7 @@
       "dependencies": {
         "jsesc": {
           "version": "0.5.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/jsesc/-/jsesc-0.5.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/jsesc/-/jsesc-0.5.0.tgz",
           "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
           "dev": true
         }
@@ -10824,31 +10824,31 @@
     },
     "relateurl": {
       "version": "0.2.7",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/relateurl/-/relateurl-0.2.7.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/relateurl/-/relateurl-0.2.7.tgz",
       "integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=",
       "dev": true
     },
     "remove-trailing-separator": {
       "version": "1.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
       "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
       "dev": true
     },
     "repeat-element": {
       "version": "1.1.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/repeat-element/-/repeat-element-1.1.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/repeat-element/-/repeat-element-1.1.3.tgz",
       "integrity": "sha1-eC4NglwMWjuzlzH4Tv7mt0Lmsc4=",
       "dev": true
     },
     "repeat-string": {
       "version": "1.6.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/repeat-string/-/repeat-string-1.6.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
       "dev": true
     },
     "repeating": {
       "version": "2.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/repeating/-/repeating-2.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/repeating/-/repeating-2.0.1.tgz",
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "dev": true,
       "requires": {
@@ -11012,13 +11012,13 @@
     },
     "replace-ext": {
       "version": "0.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/replace-ext/-/replace-ext-0.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/replace-ext/-/replace-ext-0.0.1.tgz",
       "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
       "dev": true
     },
     "request": {
       "version": "2.88.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/request/-/request-2.88.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/request/-/request-2.88.2.tgz",
       "integrity": "sha1-1zyRhzHLWofaBH4gcjQUb2ZNErM=",
       "dev": true,
       "requires": {
@@ -11046,7 +11046,7 @@
     },
     "request-promise-core": {
       "version": "1.1.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/request-promise-core/-/request-promise-core-1.1.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/request-promise-core/-/request-promise-core-1.1.3.tgz",
       "integrity": "sha1-6aPAgbUTgN/qZ3M2Bh/qh5qCnuk=",
       "dev": true,
       "requires": {
@@ -11055,7 +11055,7 @@
     },
     "request-promise-native": {
       "version": "1.0.8",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/request-promise-native/-/request-promise-native-1.0.8.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/request-promise-native/-/request-promise-native-1.0.8.tgz",
       "integrity": "sha1-pFW5YLgm5E4r+Jma9k3/K/5YyzY=",
       "dev": true,
       "requires": {
@@ -11066,31 +11066,31 @@
     },
     "require-directory": {
       "version": "2.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/require-directory/-/require-directory-2.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true
     },
     "require-main-filename": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha1-0LMp7MfMD2Fkn2IhW+aa9UqomJs=",
       "dev": true
     },
     "requirejs": {
       "version": "2.3.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/requirejs/-/requirejs-2.3.6.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/requirejs/-/requirejs-2.3.6.tgz",
       "integrity": "sha1-5Qk9lgHCgpJRJYwLlEXU0Z+p58k=",
       "dev": true
     },
     "requires-port": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/requires-port/-/requires-port-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
       "dev": true
     },
     "resolve": {
       "version": "1.17.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/resolve/-/resolve-1.17.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/resolve/-/resolve-1.17.0.tgz",
       "integrity": "sha1-sllBtUloIxzC0bt2p5y38sC/hEQ=",
       "dev": true,
       "requires": {
@@ -11099,7 +11099,7 @@
     },
     "resolve-dir": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/resolve-dir/-/resolve-dir-1.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/resolve-dir/-/resolve-dir-1.0.1.tgz",
       "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
       "dev": true,
       "requires": {
@@ -11109,19 +11109,19 @@
     },
     "resolve-from": {
       "version": "4.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/resolve-from/-/resolve-from-4.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha1-SrzYUq0y3Xuqv+m0DgCjbbXzkuY=",
       "dev": true
     },
     "resolve-url": {
       "version": "0.2.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/resolve-url/-/resolve-url-0.2.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/resolve-url/-/resolve-url-0.2.1.tgz",
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
       "dev": true
     },
     "responselike": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/responselike/-/responselike-1.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/responselike/-/responselike-1.0.2.tgz",
       "integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
       "dev": true,
       "requires": {
@@ -11130,7 +11130,7 @@
     },
     "restore-cursor": {
       "version": "3.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/restore-cursor/-/restore-cursor-3.1.0.tgz",
       "integrity": "sha1-OfZ8VLOnpYzqUjbZXPADQjljH34=",
       "dev": true,
       "requires": {
@@ -11140,19 +11140,19 @@
     },
     "ret": {
       "version": "0.1.15",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ret/-/ret-0.1.15.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ret/-/ret-0.1.15.tgz",
       "integrity": "sha1-uKSCXVvbH8P29Twrwz+BOIaBx7w=",
       "dev": true
     },
     "reusify": {
       "version": "1.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/reusify/-/reusify-1.0.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/reusify/-/reusify-1.0.4.tgz",
       "integrity": "sha1-kNo4Kx4SbvwCFG6QhFqI2xKSXXY=",
       "dev": true
     },
     "rimraf": {
       "version": "2.7.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/rimraf/-/rimraf-2.7.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/rimraf/-/rimraf-2.7.1.tgz",
       "integrity": "sha1-NXl/E6f9rcVmFCwp1PB8ytSD4+w=",
       "dev": true,
       "requires": {
@@ -11161,7 +11161,7 @@
     },
     "rollup": {
       "version": "1.32.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/rollup/-/rollup-1.32.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/rollup/-/rollup-1.32.1.tgz",
       "integrity": "sha1-RIDlLZ2eKuS0a6DZ3erzFjlA+cQ=",
       "dev": true,
       "requires": {
@@ -11172,19 +11172,19 @@
     },
     "run-async": {
       "version": "2.4.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/run-async/-/run-async-2.4.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/run-async/-/run-async-2.4.1.tgz",
       "integrity": "sha1-hEDsz5nqPnC9QJ1JqriOEMGJpFU=",
       "dev": true
     },
     "run-parallel": {
       "version": "1.1.9",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/run-parallel/-/run-parallel-1.1.9.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/run-parallel/-/run-parallel-1.1.9.tgz",
       "integrity": "sha1-yd06fPn0ssS2JE4XOm7YZuYd1nk=",
       "dev": true
     },
     "rxjs": {
       "version": "6.5.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/rxjs/-/rxjs-6.5.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/rxjs/-/rxjs-6.5.5.tgz",
       "integrity": "sha1-xciE4wlMjP7jG/J+uH5UzPyH+ew=",
       "dev": true,
       "requires": {
@@ -11193,13 +11193,13 @@
     },
     "safe-buffer": {
       "version": "5.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
       "dev": true
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/safe-regex/-/safe-regex-1.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
       "requires": {
@@ -11208,13 +11208,13 @@
     },
     "safer-buffer": {
       "version": "2.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo=",
       "dev": true
     },
     "samsam": {
       "version": "1.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/samsam/-/samsam-1.1.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/samsam/-/samsam-1.1.2.tgz",
       "integrity": "sha1-vsEf3IOp/aBjQBIQ5AF2wwJNFWc=",
       "dev": true
     },
@@ -11229,7 +11229,7 @@
     },
     "sauce-connect-launcher": {
       "version": "1.3.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/sauce-connect-launcher/-/sauce-connect-launcher-1.3.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/sauce-connect-launcher/-/sauce-connect-launcher-1.3.2.tgz",
       "integrity": "sha1-38Z1olhVCAmo6vRX65FiuUPduvA=",
       "dev": true,
       "optional": true,
@@ -11243,7 +11243,7 @@
       "dependencies": {
         "agent-base": {
           "version": "6.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/agent-base/-/agent-base-6.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/agent-base/-/agent-base-6.0.0.tgz",
           "integrity": "sha1-XQEB8Zu/rtOZgLIq6GbeFTuT8Jo=",
           "dev": true,
           "optional": true,
@@ -11253,7 +11253,7 @@
         },
         "debug": {
           "version": "4.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-4.1.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/debug/-/debug-4.1.1.tgz",
           "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
           "dev": true,
           "optional": true,
@@ -11263,7 +11263,7 @@
         },
         "https-proxy-agent": {
           "version": "5.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
           "integrity": "sha1-4qkFQqu2inYuCghQ9sntrf2FBrI=",
           "dev": true,
           "optional": true,
@@ -11274,7 +11274,7 @@
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.1.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ms/-/ms-2.1.2.tgz",
           "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
           "dev": true,
           "optional": true
@@ -11283,13 +11283,13 @@
     },
     "sax": {
       "version": "1.2.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/sax/-/sax-1.2.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/sax/-/sax-1.2.4.tgz",
       "integrity": "sha1-KBYjTiN4vdxOU1T6tcqold9xANk=",
       "dev": true
     },
     "saxes": {
       "version": "5.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/saxes/-/saxes-5.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/saxes/-/saxes-5.0.1.tgz",
       "integrity": "sha1-7rq5U/o7dgjb6U5drbFciI+maW0=",
       "dev": true,
       "requires": {
@@ -11298,32 +11298,32 @@
     },
     "scoped-regex": {
       "version": "2.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/scoped-regex/-/scoped-regex-2.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/scoped-regex/-/scoped-regex-2.1.0.tgz",
       "integrity": "sha1-e5voRdgf2dIdHsl8YaC3z4bSAV8=",
       "dev": true
     },
     "secure-compare": {
       "version": "3.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/secure-compare/-/secure-compare-3.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/secure-compare/-/secure-compare-3.0.1.tgz",
       "integrity": "sha1-8aAymzCLIh+uN7mXTz1XjQypmeM=",
       "dev": true
     },
     "select": {
       "version": "1.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/select/-/select-1.1.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/select/-/select-1.1.2.tgz",
       "integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0=",
       "dev": true,
       "optional": true
     },
     "select-hose": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/select-hose/-/select-hose-2.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/select-hose/-/select-hose-2.0.0.tgz",
       "integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo=",
       "dev": true
     },
     "selenium-standalone": {
       "version": "6.17.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/selenium-standalone/-/selenium-standalone-6.17.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/selenium-standalone/-/selenium-standalone-6.17.0.tgz",
       "integrity": "sha1-DyS2kYNiBe6bw9em8gfryygXDNk=",
       "dev": true,
       "optional": true,
@@ -11345,7 +11345,7 @@
       "dependencies": {
         "cross-spawn": {
           "version": "6.0.5",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/cross-spawn/-/cross-spawn-6.0.5.tgz",
           "integrity": "sha1-Sl7Hxk364iw6FBJNus3uhG2Ay8Q=",
           "dev": true,
           "optional": true,
@@ -11359,7 +11359,7 @@
         },
         "debug": {
           "version": "4.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-4.1.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/debug/-/debug-4.1.1.tgz",
           "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
           "dev": true,
           "optional": true,
@@ -11369,28 +11369,28 @@
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.1.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ms/-/ms-2.1.2.tgz",
           "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
           "dev": true,
           "optional": true
         },
         "path-key": {
           "version": "2.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/path-key/-/path-key-2.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/path-key/-/path-key-2.0.1.tgz",
           "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
           "dev": true,
           "optional": true
         },
         "punycode": {
           "version": "1.4.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/punycode/-/punycode-1.4.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/punycode/-/punycode-1.4.1.tgz",
           "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
           "dev": true,
           "optional": true
         },
         "request": {
           "version": "2.88.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/request/-/request-2.88.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/request/-/request-2.88.0.tgz",
           "integrity": "sha1-nC/KT301tZLv5Xx/ClXoEFIST+8=",
           "dev": true,
           "optional": true,
@@ -11419,14 +11419,14 @@
         },
         "semver": {
           "version": "5.7.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/semver/-/semver-5.7.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/semver/-/semver-5.7.1.tgz",
           "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc=",
           "dev": true,
           "optional": true
         },
         "shebang-command": {
           "version": "1.2.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/shebang-command/-/shebang-command-1.2.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/shebang-command/-/shebang-command-1.2.0.tgz",
           "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
           "dev": true,
           "optional": true,
@@ -11436,14 +11436,14 @@
         },
         "shebang-regex": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/shebang-regex/-/shebang-regex-1.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/shebang-regex/-/shebang-regex-1.0.0.tgz",
           "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
           "dev": true,
           "optional": true
         },
         "tough-cookie": {
           "version": "2.4.3",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/tough-cookie/-/tough-cookie-2.4.3.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/tough-cookie/-/tough-cookie-2.4.3.tgz",
           "integrity": "sha1-U/Nto/R3g7CSWvoG/587FlKA94E=",
           "dev": true,
           "optional": true,
@@ -11456,7 +11456,7 @@
     },
     "selenium-webdriver": {
       "version": "4.0.0-alpha.7",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/selenium-webdriver/-/selenium-webdriver-4.0.0-alpha.7.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/selenium-webdriver/-/selenium-webdriver-4.0.0-alpha.7.tgz",
       "integrity": "sha1-44edhFf9etjkQkCUt9wFQNmeZ5c=",
       "dev": true,
       "requires": {
@@ -11467,7 +11467,7 @@
       "dependencies": {
         "tmp": {
           "version": "0.0.30",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/tmp/-/tmp-0.0.30.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/tmp/-/tmp-0.0.30.tgz",
           "integrity": "sha1-ckGdSovn1s51FI/YsyTlk6cRwu0=",
           "dev": true,
           "requires": {
@@ -11478,13 +11478,13 @@
     },
     "semver": {
       "version": "5.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/semver/-/semver-5.3.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/semver/-/semver-5.3.0.tgz",
       "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
       "dev": true
     },
     "semver-diff": {
       "version": "3.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/semver-diff/-/semver-diff-3.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/semver-diff/-/semver-diff-3.1.1.tgz",
       "integrity": "sha1-Bfd85Z8yXgDicGr9Z7tQbdscoys=",
       "dev": true,
       "requires": {
@@ -11493,7 +11493,7 @@
       "dependencies": {
         "semver": {
           "version": "6.3.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/semver/-/semver-6.3.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/semver/-/semver-6.3.0.tgz",
           "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0=",
           "dev": true
         }
@@ -11501,7 +11501,7 @@
     },
     "send": {
       "version": "0.16.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/send/-/send-0.16.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/send/-/send-0.16.2.tgz",
       "integrity": "sha1-bsyh4PjBVtFBWXVZhI32RzCmu8E=",
       "dev": true,
       "requires": {
@@ -11522,7 +11522,7 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-2.6.9.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/debug/-/debug-2.6.9.tgz",
           "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
           "dev": true,
           "requires": {
@@ -11531,7 +11531,7 @@
         },
         "http-errors": {
           "version": "1.6.3",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/http-errors/-/http-errors-1.6.3.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/http-errors/-/http-errors-1.6.3.tgz",
           "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
           "dev": true,
           "requires": {
@@ -11543,25 +11543,25 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/inherits/-/inherits-2.0.3.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true
         },
         "mime": {
           "version": "1.4.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mime/-/mime-1.4.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/mime/-/mime-1.4.1.tgz",
           "integrity": "sha1-Eh+evEnjdm8xGnbh+hyAA8SwOqY=",
           "dev": true
         },
         "setprototypeof": {
           "version": "1.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/setprototypeof/-/setprototypeof-1.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/setprototypeof/-/setprototypeof-1.1.0.tgz",
           "integrity": "sha1-0L2FU2iHtv58DYGMuWLZ2RxU5lY=",
           "dev": true
         },
         "statuses": {
           "version": "1.4.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/statuses/-/statuses-1.4.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/statuses/-/statuses-1.4.0.tgz",
           "integrity": "sha1-u3PURtonlhBu/MG2AaJT1sRr0Ic=",
           "dev": true
         }
@@ -11569,7 +11569,7 @@
     },
     "serve-static": {
       "version": "1.14.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/serve-static/-/serve-static-1.14.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/serve-static/-/serve-static-1.14.1.tgz",
       "integrity": "sha1-Zm5jbcTwEPfvKZcKiKZ0MgiYsvk=",
       "dev": true,
       "requires": {
@@ -11581,7 +11581,7 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-2.6.9.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/debug/-/debug-2.6.9.tgz",
           "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
           "dev": true,
           "requires": {
@@ -11590,7 +11590,7 @@
           "dependencies": {
             "ms": {
               "version": "2.0.0",
-              "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.0.0.tgz",
+              "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ms/-/ms-2.0.0.tgz",
               "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
               "dev": true
             }
@@ -11598,13 +11598,13 @@
         },
         "ms": {
           "version": "2.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.1.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ms/-/ms-2.1.1.tgz",
           "integrity": "sha1-MKWGTrPrsKZvLr5tcnrwagnYbgo=",
           "dev": true
         },
         "send": {
           "version": "0.17.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/send/-/send-0.17.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/send/-/send-0.17.1.tgz",
           "integrity": "sha1-wdiwWfeQD3Rm3Uk4vcROEd2zdsg=",
           "dev": true,
           "requires": {
@@ -11627,31 +11627,31 @@
     },
     "server-destroy": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/server-destroy/-/server-destroy-1.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/server-destroy/-/server-destroy-1.0.1.tgz",
       "integrity": "sha1-8Tv5KOQrnD55OD5hzDmYtdFObN0=",
       "dev": true
     },
     "serviceworker-cache-polyfill": {
       "version": "4.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/serviceworker-cache-polyfill/-/serviceworker-cache-polyfill-4.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/serviceworker-cache-polyfill/-/serviceworker-cache-polyfill-4.0.0.tgz",
       "integrity": "sha1-3hnuc77yGrPAdAo3sz22JGS6ves=",
       "dev": true
     },
     "set-blocking": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/set-blocking/-/set-blocking-2.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true
     },
     "set-immediate-shim": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
       "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
       "dev": true
     },
     "set-value": {
       "version": "2.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/set-value/-/set-value-2.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/set-value/-/set-value-2.0.1.tgz",
       "integrity": "sha1-oY1AUw5vB95CKMfe/kInr4ytAFs=",
       "dev": true,
       "requires": {
@@ -11663,7 +11663,7 @@
       "dependencies": {
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
@@ -11674,19 +11674,19 @@
     },
     "setprototypeof": {
       "version": "1.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/setprototypeof/-/setprototypeof-1.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/setprototypeof/-/setprototypeof-1.1.1.tgz",
       "integrity": "sha1-fpWsskqpL1iF4KvvW6ExMw1K5oM=",
       "dev": true
     },
     "shady-css-parser": {
       "version": "0.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/shady-css-parser/-/shady-css-parser-0.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/shady-css-parser/-/shady-css-parser-0.1.0.tgz",
       "integrity": "sha1-U03HnIyliExe2SpOWhPW2GO8pCg=",
       "dev": true
     },
     "shebang-command": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/shebang-command/-/shebang-command-2.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha1-zNCvT4g1+9wmW4JGGq8MNmY/NOo=",
       "dev": true,
       "requires": {
@@ -11695,19 +11695,19 @@
     },
     "shebang-regex": {
       "version": "3.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha1-rhbxZE2HPsrYQ7AwexQzYtTEIXI=",
       "dev": true
     },
     "signal-exit": {
       "version": "3.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/signal-exit/-/signal-exit-3.0.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/signal-exit/-/signal-exit-3.0.3.tgz",
       "integrity": "sha1-oUEMLt2PB3sItOJTyOrPyvBXRhw=",
       "dev": true
     },
     "simple-swizzle": {
       "version": "0.2.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
       "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
       "dev": true,
       "requires": {
@@ -11716,7 +11716,7 @@
       "dependencies": {
         "is-arrayish": {
           "version": "0.3.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-arrayish/-/is-arrayish-0.3.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-arrayish/-/is-arrayish-0.3.2.tgz",
           "integrity": "sha1-RXSirlb3qyBolvtDHq7tBm/fjwM=",
           "dev": true
         }
@@ -11724,7 +11724,7 @@
     },
     "sinon": {
       "version": "9.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/sinon/-/sinon-9.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/sinon/-/sinon-9.0.2.tgz",
       "integrity": "sha1-uQF+JGM/SxyY37bnhKXwUJ9f2F0=",
       "dev": true,
       "requires": {
@@ -11739,19 +11739,19 @@
       "dependencies": {
         "diff": {
           "version": "4.0.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/diff/-/diff-4.0.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/diff/-/diff-4.0.2.tgz",
           "integrity": "sha1-YPOuy4nV+uUgwRqhnvwruYKq3n0=",
           "dev": true
         },
         "has-flag": {
           "version": "4.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/has-flag/-/has-flag-4.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
           "dev": true
         },
         "supports-color": {
           "version": "7.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/supports-color/-/supports-color-7.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/supports-color/-/supports-color-7.1.0.tgz",
           "integrity": "sha1-aOMlkd9z4lrRxLSRCKLsUHliv9E=",
           "dev": true,
           "requires": {
@@ -11762,19 +11762,19 @@
     },
     "sinon-chai": {
       "version": "2.14.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/sinon-chai/-/sinon-chai-2.14.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/sinon-chai/-/sinon-chai-2.14.0.tgz",
       "integrity": "sha1-2n3UzIPNaiYLZ8yg96n9riahIF0=",
       "dev": true
     },
     "slash": {
       "version": "3.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/slash/-/slash-3.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/slash/-/slash-3.0.0.tgz",
       "integrity": "sha1-ZTm+hwwWWtvVJAIg2+Nh8bxNRjQ=",
       "dev": true
     },
     "slice-ansi": {
       "version": "2.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/slice-ansi/-/slice-ansi-2.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/slice-ansi/-/slice-ansi-2.1.0.tgz",
       "integrity": "sha1-ys12k0YaY3pXiNkqfdT7oGjoFjY=",
       "dev": true,
       "requires": {
@@ -11785,7 +11785,7 @@
       "dependencies": {
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         }
@@ -11793,7 +11793,7 @@
     },
     "snapdragon": {
       "version": "0.8.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/snapdragon/-/snapdragon-0.8.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/snapdragon/-/snapdragon-0.8.2.tgz",
       "integrity": "sha1-ZJIufFZbDhQgS6GqfWlkJ40lGC0=",
       "dev": true,
       "requires": {
@@ -11809,7 +11809,7 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-2.6.9.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/debug/-/debug-2.6.9.tgz",
           "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
           "dev": true,
           "requires": {
@@ -11818,7 +11818,7 @@
         },
         "define-property": {
           "version": "0.2.5",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/define-property/-/define-property-0.2.5.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
@@ -11827,7 +11827,7 @@
         },
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
@@ -11836,7 +11836,7 @@
         },
         "source-map": {
           "version": "0.5.7",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/source-map/-/source-map-0.5.7.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "dev": true
         }
@@ -11844,7 +11844,7 @@
     },
     "snapdragon-node": {
       "version": "2.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
       "integrity": "sha1-bBdfhv8UvbByRWPo88GwIaKGhTs=",
       "dev": true,
       "requires": {
@@ -11855,7 +11855,7 @@
       "dependencies": {
         "define-property": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/define-property/-/define-property-1.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
@@ -11864,7 +11864,7 @@
         },
         "is-accessor-descriptor": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
           "dev": true,
           "requires": {
@@ -11873,7 +11873,7 @@
         },
         "is-data-descriptor": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
           "dev": true,
           "requires": {
@@ -11882,7 +11882,7 @@
         },
         "is-descriptor": {
           "version": "1.0.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
           "dev": true,
           "requires": {
@@ -11895,7 +11895,7 @@
     },
     "snapdragon-util": {
       "version": "3.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
       "integrity": "sha1-+VZHlIbyrNeXAGk/b3uAXkWrVuI=",
       "dev": true,
       "requires": {
@@ -11904,13 +11904,13 @@
       "dependencies": {
         "is-buffer": {
           "version": "1.1.6",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-buffer/-/is-buffer-1.1.6.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-buffer/-/is-buffer-1.1.6.tgz",
           "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
           "dev": true
         },
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
@@ -11921,7 +11921,7 @@
     },
     "socket.io": {
       "version": "2.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/socket.io/-/socket.io-2.3.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/socket.io/-/socket.io-2.3.0.tgz",
       "integrity": "sha1-zXYu1qT67KWbwfPiQ8CWkxHrc/s=",
       "dev": true,
       "requires": {
@@ -11935,7 +11935,7 @@
       "dependencies": {
         "debug": {
           "version": "4.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-4.1.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/debug/-/debug-4.1.1.tgz",
           "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
           "dev": true,
           "requires": {
@@ -11944,7 +11944,7 @@
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.1.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ms/-/ms-2.1.2.tgz",
           "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
           "dev": true
         }
@@ -11952,13 +11952,13 @@
     },
     "socket.io-adapter": {
       "version": "1.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/socket.io-adapter/-/socket.io-adapter-1.1.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/socket.io-adapter/-/socket.io-adapter-1.1.2.tgz",
       "integrity": "sha1-qz8Nb2a4/H/KOVmrWZH4IiF4m+k=",
       "dev": true
     },
     "socket.io-client": {
       "version": "2.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/socket.io-client/-/socket.io-client-2.3.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/socket.io-client/-/socket.io-client-2.3.0.tgz",
       "integrity": "sha1-FNW6LgC5vNFFrkQ6uWs/hsvMG7Q=",
       "dev": true,
       "requires": {
@@ -11980,13 +11980,13 @@
       "dependencies": {
         "component-emitter": {
           "version": "1.2.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/component-emitter/-/component-emitter-1.2.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/component-emitter/-/component-emitter-1.2.1.tgz",
           "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
           "dev": true
         },
         "debug": {
           "version": "4.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-4.1.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/debug/-/debug-4.1.1.tgz",
           "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
           "dev": true,
           "requires": {
@@ -11995,19 +11995,19 @@
         },
         "isarray": {
           "version": "2.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/isarray/-/isarray-2.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/isarray/-/isarray-2.0.1.tgz",
           "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4=",
           "dev": true
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.1.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ms/-/ms-2.1.2.tgz",
           "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
           "dev": true
         },
         "socket.io-parser": {
           "version": "3.3.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/socket.io-parser/-/socket.io-parser-3.3.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/socket.io-parser/-/socket.io-parser-3.3.0.tgz",
           "integrity": "sha1-K1KpalCf3zFEC6QP7WCUx9TxJi8=",
           "dev": true,
           "requires": {
@@ -12018,7 +12018,7 @@
           "dependencies": {
             "debug": {
               "version": "3.1.0",
-              "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-3.1.0.tgz",
+              "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/debug/-/debug-3.1.0.tgz",
               "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
               "dev": true,
               "requires": {
@@ -12027,7 +12027,7 @@
             },
             "ms": {
               "version": "2.0.0",
-              "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.0.0.tgz",
+              "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ms/-/ms-2.0.0.tgz",
               "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
               "dev": true
             }
@@ -12037,7 +12037,7 @@
     },
     "socket.io-parser": {
       "version": "3.4.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/socket.io-parser/-/socket.io-parser-3.4.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/socket.io-parser/-/socket.io-parser-3.4.1.tgz",
       "integrity": "sha1-sGr4ODApdYN+qy3JgAN9okBU1ko=",
       "dev": true,
       "requires": {
@@ -12048,13 +12048,13 @@
       "dependencies": {
         "component-emitter": {
           "version": "1.2.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/component-emitter/-/component-emitter-1.2.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/component-emitter/-/component-emitter-1.2.1.tgz",
           "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
           "dev": true
         },
         "debug": {
           "version": "4.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-4.1.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/debug/-/debug-4.1.1.tgz",
           "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
           "dev": true,
           "requires": {
@@ -12063,13 +12063,13 @@
         },
         "isarray": {
           "version": "2.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/isarray/-/isarray-2.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/isarray/-/isarray-2.0.1.tgz",
           "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4=",
           "dev": true
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.1.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ms/-/ms-2.1.2.tgz",
           "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
           "dev": true
         }
@@ -12077,13 +12077,13 @@
     },
     "source-map": {
       "version": "0.6.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/source-map/-/source-map-0.6.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
       "dev": true
     },
     "source-map-resolve": {
       "version": "0.5.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
       "integrity": "sha1-GQhmvs51U+H48mei7oLGBrVQmho=",
       "dev": true,
       "requires": {
@@ -12096,7 +12096,7 @@
     },
     "source-map-support": {
       "version": "0.5.19",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/source-map-support/-/source-map-support-0.5.19.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/source-map-support/-/source-map-support-0.5.19.tgz",
       "integrity": "sha1-qYti+G3K9PZzmWSMCFKRq56P7WE=",
       "dev": true,
       "requires": {
@@ -12106,13 +12106,13 @@
     },
     "source-map-url": {
       "version": "0.4.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/source-map-url/-/source-map-url-0.4.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/source-map-url/-/source-map-url-0.4.0.tgz",
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
       "dev": true
     },
     "spdx-correct": {
       "version": "3.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/spdx-correct/-/spdx-correct-3.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/spdx-correct/-/spdx-correct-3.1.1.tgz",
       "integrity": "sha1-3s6BrJweZxPl99G28X1Gj6U9iak=",
       "dev": true,
       "requires": {
@@ -12122,13 +12122,13 @@
     },
     "spdx-exceptions": {
       "version": "2.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
       "integrity": "sha1-PyjOGnegA3JoPq3kpDMYNSeiFj0=",
       "dev": true
     },
     "spdx-expression-parse": {
       "version": "3.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
       "integrity": "sha1-z3D1BILu/cmOPOCmgz5KU87rpnk=",
       "dev": true,
       "requires": {
@@ -12138,13 +12138,13 @@
     },
     "spdx-license-ids": {
       "version": "3.0.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
       "integrity": "sha1-NpS1gEVnpFjTyARYQqY1hjL2JlQ=",
       "dev": true
     },
     "spdy": {
       "version": "3.4.7",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/spdy/-/spdy-3.4.7.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/spdy/-/spdy-3.4.7.tgz",
       "integrity": "sha1-Qv9B7OXMD5mjpsKKq7c/XDsDrLw=",
       "dev": true,
       "requires": {
@@ -12158,7 +12158,7 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-2.6.9.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/debug/-/debug-2.6.9.tgz",
           "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
           "dev": true,
           "requires": {
@@ -12169,7 +12169,7 @@
     },
     "spdy-transport": {
       "version": "2.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/spdy-transport/-/spdy-transport-2.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/spdy-transport/-/spdy-transport-2.1.1.tgz",
       "integrity": "sha1-xUgV1zhYqt0GzmMAHn0l+mRBYjs=",
       "dev": true,
       "requires": {
@@ -12184,7 +12184,7 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-2.6.9.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/debug/-/debug-2.6.9.tgz",
           "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
           "dev": true,
           "requires": {
@@ -12195,7 +12195,7 @@
     },
     "split": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/split/-/split-1.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/split/-/split-1.0.1.tgz",
       "integrity": "sha1-YFvZvjA6pZ+zX5Ip++oN3snqB9k=",
       "dev": true,
       "requires": {
@@ -12204,7 +12204,7 @@
     },
     "split-string": {
       "version": "3.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/split-string/-/split-string-3.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/split-string/-/split-string-3.1.0.tgz",
       "integrity": "sha1-fLCd2jqGWFcFxks5pkZgOGguj+I=",
       "dev": true,
       "requires": {
@@ -12213,13 +12213,13 @@
     },
     "sprintf-js": {
       "version": "1.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
     "sshpk": {
       "version": "1.16.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/sshpk/-/sshpk-1.16.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/sshpk/-/sshpk-1.16.1.tgz",
       "integrity": "sha1-+2YcC+8ps520B2nuOfpwCT1vaHc=",
       "dev": true,
       "requires": {
@@ -12236,19 +12236,19 @@
     },
     "stable": {
       "version": "0.1.8",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/stable/-/stable-0.1.8.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/stable/-/stable-0.1.8.tgz",
       "integrity": "sha1-g26zyDgv4pNv6vVEYxAXzn1Ho88=",
       "dev": true
     },
     "stack-trace": {
       "version": "0.0.10",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/stack-trace/-/stack-trace-0.0.10.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/stack-trace/-/stack-trace-0.0.10.tgz",
       "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
       "dev": true
     },
     "stacky": {
       "version": "1.3.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/stacky/-/stacky-1.3.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/stacky/-/stacky-1.3.1.tgz",
       "integrity": "sha1-PxF+UYe5pz0j+HbWnwXIWxGAShI=",
       "dev": true,
       "requires": {
@@ -12258,13 +12258,13 @@
       "dependencies": {
         "ansi-styles": {
           "version": "2.2.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-styles/-/ansi-styles-2.2.1.tgz",
           "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
           "dev": true
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -12277,13 +12277,13 @@
         },
         "lodash": {
           "version": "3.10.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash/-/lodash-3.10.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
           "dev": true
         },
         "supports-color": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/supports-color/-/supports-color-2.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/supports-color/-/supports-color-2.0.0.tgz",
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         }
@@ -12291,7 +12291,7 @@
     },
     "static-extend": {
       "version": "0.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/static-extend/-/static-extend-0.1.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/static-extend/-/static-extend-0.1.2.tgz",
       "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
       "dev": true,
       "requires": {
@@ -12301,7 +12301,7 @@
       "dependencies": {
         "define-property": {
           "version": "0.2.5",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/define-property/-/define-property-0.2.5.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
@@ -12312,19 +12312,19 @@
     },
     "statuses": {
       "version": "1.5.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/statuses/-/statuses-1.5.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/statuses/-/statuses-1.5.0.tgz",
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
       "dev": true
     },
     "stealthy-require": {
       "version": "1.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/stealthy-require/-/stealthy-require-1.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/stealthy-require/-/stealthy-require-1.1.1.tgz",
       "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
       "dev": true
     },
     "stream": {
       "version": "0.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/stream/-/stream-0.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/stream/-/stream-0.0.2.tgz",
       "integrity": "sha1-f1Nj8Ff2WSxVlfALyAon9c7B8O8=",
       "dev": true,
       "requires": {
@@ -12333,7 +12333,7 @@
     },
     "stream-combiner": {
       "version": "0.2.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/stream-combiner/-/stream-combiner-0.2.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/stream-combiner/-/stream-combiner-0.2.2.tgz",
       "integrity": "sha1-rsjLrBd7Vrb0+kec7YwZEs7lKFg=",
       "dev": true,
       "requires": {
@@ -12343,19 +12343,19 @@
     },
     "stream-shift": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/stream-shift/-/stream-shift-1.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/stream-shift/-/stream-shift-1.0.1.tgz",
       "integrity": "sha1-1wiCgVWasneEJCebCHfaPDktWj0=",
       "dev": true
     },
     "streamsearch": {
       "version": "0.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/streamsearch/-/streamsearch-0.1.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/streamsearch/-/streamsearch-0.1.2.tgz",
       "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo=",
       "dev": true
     },
     "string-width": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string-width/-/string-width-1.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "dev": true,
       "requires": {
@@ -12366,19 +12366,19 @@
     },
     "string.fromcodepoint": {
       "version": "0.2.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string.fromcodepoint/-/string.fromcodepoint-0.2.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/string.fromcodepoint/-/string.fromcodepoint-0.2.1.tgz",
       "integrity": "sha1-jZeDM8C8klOPUPOD5IiPPlYZ1lM=",
       "dev": true
     },
     "string.prototype.codepointat": {
       "version": "0.2.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string.prototype.codepointat/-/string.prototype.codepointat-0.2.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/string.prototype.codepointat/-/string.prototype.codepointat-0.2.1.tgz",
       "integrity": "sha1-AErUTIr8cnUnsQjNRitNlxzUabw=",
       "dev": true
     },
     "string.prototype.trimend": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz",
       "integrity": "sha1-hYEqa4R6wAInD1gIFGBkyZX7aRM=",
       "dev": true,
       "requires": {
@@ -12388,7 +12388,7 @@
     },
     "string.prototype.trimleft": {
       "version": "2.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string.prototype.trimleft/-/string.prototype.trimleft-2.1.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/string.prototype.trimleft/-/string.prototype.trimleft-2.1.2.tgz",
       "integrity": "sha1-RAiqLl1t3QyagHObCH+8BnwDs8w=",
       "dev": true,
       "requires": {
@@ -12399,7 +12399,7 @@
     },
     "string.prototype.trimright": {
       "version": "2.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string.prototype.trimright/-/string.prototype.trimright-2.1.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/string.prototype.trimright/-/string.prototype.trimright-2.1.2.tgz",
       "integrity": "sha1-x28c7zDyG7rYr+uNsVEUls+w8qM=",
       "dev": true,
       "requires": {
@@ -12410,7 +12410,7 @@
     },
     "string.prototype.trimstart": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz",
       "integrity": "sha1-FK9tnzSwU/fPyJty+PLuFLkDmlQ=",
       "dev": true,
       "requires": {
@@ -12420,13 +12420,13 @@
     },
     "string_decoder": {
       "version": "0.10.31",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string_decoder/-/string_decoder-0.10.31.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/string_decoder/-/string_decoder-0.10.31.tgz",
       "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
       "dev": true
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
@@ -12435,7 +12435,7 @@
     },
     "strip-bom": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-bom/-/strip-bom-2.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/strip-bom/-/strip-bom-2.0.0.tgz",
       "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
       "dev": true,
       "requires": {
@@ -12444,7 +12444,7 @@
     },
     "strip-bom-stream": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz",
       "integrity": "sha1-5xRDmFd9Uaa+0PoZlPoF9D/ZiO4=",
       "dev": true,
       "requires": {
@@ -12454,19 +12454,19 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
     },
     "strip-final-newline": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
       "integrity": "sha1-ibhS+y/L6Tb29LMYevsKEsGrWK0=",
       "dev": true
     },
     "strip-indent": {
       "version": "3.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-indent/-/strip-indent-3.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/strip-indent/-/strip-indent-3.0.0.tgz",
       "integrity": "sha1-wy4c7pQLazQyx3G8LFS8znPNMAE=",
       "dev": true,
       "requires": {
@@ -12475,13 +12475,13 @@
     },
     "strip-json-comments": {
       "version": "3.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-json-comments/-/strip-json-comments-3.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/strip-json-comments/-/strip-json-comments-3.1.0.tgz",
       "integrity": "sha1-djjTFCISns9EV0QACfugP5+awYA=",
       "dev": true
     },
     "supports-color": {
       "version": "5.5.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/supports-color/-/supports-color-5.5.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
       "dev": true,
       "requires": {
@@ -12490,7 +12490,7 @@
     },
     "supports-hyperlinks": {
       "version": "2.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/supports-hyperlinks/-/supports-hyperlinks-2.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/supports-hyperlinks/-/supports-hyperlinks-2.1.0.tgz",
       "integrity": "sha1-9mPfJSr183xdSbvX7u+p4Lnlnkc=",
       "dev": true,
       "requires": {
@@ -12500,13 +12500,13 @@
       "dependencies": {
         "has-flag": {
           "version": "4.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/has-flag/-/has-flag-4.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
           "dev": true
         },
         "supports-color": {
           "version": "7.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/supports-color/-/supports-color-7.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/supports-color/-/supports-color-7.1.0.tgz",
           "integrity": "sha1-aOMlkd9z4lrRxLSRCKLsUHliv9E=",
           "dev": true,
           "requires": {
@@ -12517,7 +12517,7 @@
     },
     "svg-pathdata": {
       "version": "1.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/svg-pathdata/-/svg-pathdata-1.0.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/svg-pathdata/-/svg-pathdata-1.0.4.tgz",
       "integrity": "sha1-emgTQqrH7/2NUq+6eZmRDJ2juVk=",
       "dev": true,
       "requires": {
@@ -12526,19 +12526,19 @@
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/isarray/-/isarray-1.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true
         },
         "process-nextick-args": {
           "version": "1.0.7",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
           "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
           "dev": true
         },
         "readable-stream": {
           "version": "2.0.6",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/readable-stream/-/readable-stream-2.0.6.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/readable-stream/-/readable-stream-2.0.6.tgz",
           "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
           "dev": true,
           "requires": {
@@ -12554,7 +12554,7 @@
     },
     "svg2ttf": {
       "version": "4.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/svg2ttf/-/svg2ttf-4.3.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/svg2ttf/-/svg2ttf-4.3.0.tgz",
       "integrity": "sha1-QzRAx+kGL4/c7DytchzQiix+UeM=",
       "dev": true,
       "requires": {
@@ -12568,7 +12568,7 @@
     },
     "svgicons2svgfont": {
       "version": "5.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/svgicons2svgfont/-/svgicons2svgfont-5.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/svgicons2svgfont/-/svgicons2svgfont-5.0.2.tgz",
       "integrity": "sha1-BRGCPGSRvhp9VDKS4pqK5ietBAY=",
       "dev": true,
       "requires": {
@@ -12583,13 +12583,13 @@
     },
     "svgpath": {
       "version": "2.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/svgpath/-/svgpath-2.3.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/svgpath/-/svgpath-2.3.0.tgz",
       "integrity": "sha1-78dnBd6ra9F3Tp8O0Di7ZhteTSM=",
       "dev": true
     },
     "sw-precache": {
       "version": "5.2.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/sw-precache/-/sw-precache-5.2.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/sw-precache/-/sw-precache-5.2.1.tgz",
       "integrity": "sha1-BhNPMZ7saPO5WDzppwNrHBGfcXk=",
       "dev": true,
       "requires": {
@@ -12607,7 +12607,7 @@
       "dependencies": {
         "ansi-align": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-align/-/ansi-align-2.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-align/-/ansi-align-2.0.0.tgz",
           "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
           "dev": true,
           "requires": {
@@ -12616,13 +12616,13 @@
         },
         "ansi-regex": {
           "version": "3.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
         "boxen": {
           "version": "1.3.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/boxen/-/boxen-1.3.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/boxen/-/boxen-1.3.0.tgz",
           "integrity": "sha1-VcbDmouljZxhrSLNh3Uy3rZlogs=",
           "dev": true,
           "requires": {
@@ -12637,7 +12637,7 @@
           "dependencies": {
             "camelcase": {
               "version": "4.1.0",
-              "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/camelcase/-/camelcase-4.1.0.tgz",
+              "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/camelcase/-/camelcase-4.1.0.tgz",
               "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
               "dev": true
             }
@@ -12645,13 +12645,13 @@
         },
         "camelcase": {
           "version": "2.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/camelcase/-/camelcase-2.1.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/camelcase/-/camelcase-2.1.1.tgz",
           "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
           "dev": true
         },
         "camelcase-keys": {
           "version": "2.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
           "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
           "dev": true,
           "requires": {
@@ -12661,7 +12661,7 @@
         },
         "chalk": {
           "version": "2.4.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/chalk/-/chalk-2.4.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
           "dev": true,
           "requires": {
@@ -12672,19 +12672,19 @@
         },
         "ci-info": {
           "version": "1.6.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ci-info/-/ci-info-1.6.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ci-info/-/ci-info-1.6.0.tgz",
           "integrity": "sha1-LKINu5zrMtRSSmgzAzE/AwSx5Jc=",
           "dev": true
         },
         "cli-boxes": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cli-boxes/-/cli-boxes-1.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/cli-boxes/-/cli-boxes-1.0.0.tgz",
           "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
           "dev": true
         },
         "configstore": {
           "version": "3.1.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/configstore/-/configstore-3.1.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/configstore/-/configstore-3.1.2.tgz",
           "integrity": "sha1-xvJd767vJt8S3TNBSwAf6BpUP48=",
           "dev": true,
           "requires": {
@@ -12698,7 +12698,7 @@
         },
         "cross-spawn": {
           "version": "5.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cross-spawn/-/cross-spawn-5.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/cross-spawn/-/cross-spawn-5.1.0.tgz",
           "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
           "dev": true,
           "requires": {
@@ -12709,13 +12709,13 @@
         },
         "crypto-random-string": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
           "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
           "dev": true
         },
         "dot-prop": {
           "version": "4.2.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/dot-prop/-/dot-prop-4.2.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/dot-prop/-/dot-prop-4.2.0.tgz",
           "integrity": "sha1-HxngwuGqDjJ5fEl5nyg3rGr2nFc=",
           "dev": true,
           "requires": {
@@ -12724,7 +12724,7 @@
         },
         "execa": {
           "version": "0.7.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/execa/-/execa-0.7.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/execa/-/execa-0.7.0.tgz",
           "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
           "dev": true,
           "requires": {
@@ -12739,7 +12739,7 @@
         },
         "find-up": {
           "version": "1.1.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/find-up/-/find-up-1.1.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/find-up/-/find-up-1.1.2.tgz",
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "dev": true,
           "requires": {
@@ -12749,13 +12749,13 @@
         },
         "get-stream": {
           "version": "3.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/get-stream/-/get-stream-3.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/get-stream/-/get-stream-3.0.0.tgz",
           "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
           "dev": true
         },
         "global-dirs": {
           "version": "0.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/global-dirs/-/global-dirs-0.1.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/global-dirs/-/global-dirs-0.1.1.tgz",
           "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
           "dev": true,
           "requires": {
@@ -12764,7 +12764,7 @@
         },
         "got": {
           "version": "6.7.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/got/-/got-6.7.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/got/-/got-6.7.1.tgz",
           "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
           "dev": true,
           "requires": {
@@ -12783,7 +12783,7 @@
         },
         "indent-string": {
           "version": "2.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/indent-string/-/indent-string-2.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/indent-string/-/indent-string-2.1.0.tgz",
           "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
           "dev": true,
           "requires": {
@@ -12792,7 +12792,7 @@
         },
         "is-ci": {
           "version": "1.2.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-ci/-/is-ci-1.2.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-ci/-/is-ci-1.2.1.tgz",
           "integrity": "sha1-43ecjuF/zPQoSI9uKBGH8uYyhBw=",
           "dev": true,
           "requires": {
@@ -12801,13 +12801,13 @@
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
         "is-installed-globally": {
           "version": "0.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
           "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
           "dev": true,
           "requires": {
@@ -12817,19 +12817,19 @@
         },
         "is-npm": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-npm/-/is-npm-1.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-npm/-/is-npm-1.0.0.tgz",
           "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
           "dev": true
         },
         "is-obj": {
           "version": "1.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-obj/-/is-obj-1.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-obj/-/is-obj-1.0.1.tgz",
           "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
           "dev": true
         },
         "is-path-inside": {
           "version": "1.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-path-inside/-/is-path-inside-1.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-path-inside/-/is-path-inside-1.0.1.tgz",
           "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
           "dev": true,
           "requires": {
@@ -12838,7 +12838,7 @@
         },
         "latest-version": {
           "version": "3.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/latest-version/-/latest-version-3.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/latest-version/-/latest-version-3.1.0.tgz",
           "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
           "dev": true,
           "requires": {
@@ -12847,7 +12847,7 @@
         },
         "lru-cache": {
           "version": "4.1.5",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lru-cache/-/lru-cache-4.1.5.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lru-cache/-/lru-cache-4.1.5.tgz",
           "integrity": "sha1-i75Q6oW+1ZvJ4z3KuCNe6bz0Q80=",
           "dev": true,
           "requires": {
@@ -12857,7 +12857,7 @@
         },
         "make-dir": {
           "version": "1.3.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/make-dir/-/make-dir-1.3.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/make-dir/-/make-dir-1.3.0.tgz",
           "integrity": "sha1-ecEDO4BRW9bSTsmTPoYMp17ifww=",
           "dev": true,
           "requires": {
@@ -12866,7 +12866,7 @@
           "dependencies": {
             "pify": {
               "version": "3.0.0",
-              "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/pify/-/pify-3.0.0.tgz",
+              "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/pify/-/pify-3.0.0.tgz",
               "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
               "dev": true
             }
@@ -12874,13 +12874,13 @@
         },
         "map-obj": {
           "version": "1.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/map-obj/-/map-obj-1.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/map-obj/-/map-obj-1.0.1.tgz",
           "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
           "dev": true
         },
         "meow": {
           "version": "3.7.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/meow/-/meow-3.7.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/meow/-/meow-3.7.0.tgz",
           "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
           "dev": true,
           "requires": {
@@ -12898,7 +12898,7 @@
         },
         "npm-run-path": {
           "version": "2.0.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/npm-run-path/-/npm-run-path-2.0.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/npm-run-path/-/npm-run-path-2.0.2.tgz",
           "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
           "dev": true,
           "requires": {
@@ -12907,7 +12907,7 @@
         },
         "package-json": {
           "version": "4.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/package-json/-/package-json-4.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/package-json/-/package-json-4.0.1.tgz",
           "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
           "dev": true,
           "requires": {
@@ -12919,7 +12919,7 @@
         },
         "path-exists": {
           "version": "2.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/path-exists/-/path-exists-2.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/path-exists/-/path-exists-2.1.0.tgz",
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "dev": true,
           "requires": {
@@ -12928,13 +12928,13 @@
         },
         "path-key": {
           "version": "2.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/path-key/-/path-key-2.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/path-key/-/path-key-2.0.1.tgz",
           "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
           "dev": true
         },
         "path-type": {
           "version": "1.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/path-type/-/path-type-1.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/path-type/-/path-type-1.1.0.tgz",
           "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
           "dev": true,
           "requires": {
@@ -12945,13 +12945,13 @@
         },
         "pify": {
           "version": "2.3.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/pify/-/pify-2.3.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         },
         "read-pkg": {
           "version": "1.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/read-pkg/-/read-pkg-1.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/read-pkg/-/read-pkg-1.1.0.tgz",
           "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
           "dev": true,
           "requires": {
@@ -12962,7 +12962,7 @@
         },
         "read-pkg-up": {
           "version": "1.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
           "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
           "dev": true,
           "requires": {
@@ -12972,7 +12972,7 @@
         },
         "redent": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/redent/-/redent-1.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/redent/-/redent-1.0.0.tgz",
           "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
           "dev": true,
           "requires": {
@@ -12982,7 +12982,7 @@
         },
         "registry-auth-token": {
           "version": "3.4.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/registry-auth-token/-/registry-auth-token-3.4.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/registry-auth-token/-/registry-auth-token-3.4.0.tgz",
           "integrity": "sha1-10RoFUM/XV7WQxzV3KIQSPZrOX4=",
           "dev": true,
           "requires": {
@@ -12992,7 +12992,7 @@
         },
         "registry-url": {
           "version": "3.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/registry-url/-/registry-url-3.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/registry-url/-/registry-url-3.1.0.tgz",
           "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
           "dev": true,
           "requires": {
@@ -13001,7 +13001,7 @@
         },
         "semver-diff": {
           "version": "2.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/semver-diff/-/semver-diff-2.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/semver-diff/-/semver-diff-2.1.0.tgz",
           "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
           "dev": true,
           "requires": {
@@ -13010,7 +13010,7 @@
         },
         "shebang-command": {
           "version": "1.2.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/shebang-command/-/shebang-command-1.2.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/shebang-command/-/shebang-command-1.2.0.tgz",
           "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
           "dev": true,
           "requires": {
@@ -13019,13 +13019,13 @@
         },
         "shebang-regex": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/shebang-regex/-/shebang-regex-1.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/shebang-regex/-/shebang-regex-1.0.0.tgz",
           "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
           "dev": true
         },
         "string-width": {
           "version": "2.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string-width/-/string-width-2.1.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/string-width/-/string-width-2.1.1.tgz",
           "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
           "dev": true,
           "requires": {
@@ -13035,7 +13035,7 @@
         },
         "strip-ansi": {
           "version": "4.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
@@ -13044,7 +13044,7 @@
         },
         "strip-indent": {
           "version": "1.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-indent/-/strip-indent-1.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/strip-indent/-/strip-indent-1.0.1.tgz",
           "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
           "dev": true,
           "requires": {
@@ -13053,7 +13053,7 @@
         },
         "term-size": {
           "version": "1.2.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/term-size/-/term-size-1.2.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/term-size/-/term-size-1.2.0.tgz",
           "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
           "dev": true,
           "requires": {
@@ -13062,19 +13062,19 @@
         },
         "timed-out": {
           "version": "4.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/timed-out/-/timed-out-4.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/timed-out/-/timed-out-4.0.1.tgz",
           "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
           "dev": true
         },
         "trim-newlines": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/trim-newlines/-/trim-newlines-1.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/trim-newlines/-/trim-newlines-1.0.0.tgz",
           "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
           "dev": true
         },
         "unique-string": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/unique-string/-/unique-string-1.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/unique-string/-/unique-string-1.0.0.tgz",
           "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
           "dev": true,
           "requires": {
@@ -13083,13 +13083,13 @@
         },
         "unzip-response": {
           "version": "2.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/unzip-response/-/unzip-response-2.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/unzip-response/-/unzip-response-2.0.1.tgz",
           "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
           "dev": true
         },
         "update-notifier": {
           "version": "2.5.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/update-notifier/-/update-notifier-2.5.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/update-notifier/-/update-notifier-2.5.0.tgz",
           "integrity": "sha1-0HRFk+E/Fh5AassdlAi3LK0Ir/Y=",
           "dev": true,
           "requires": {
@@ -13107,7 +13107,7 @@
         },
         "widest-line": {
           "version": "2.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/widest-line/-/widest-line-2.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/widest-line/-/widest-line-2.0.1.tgz",
           "integrity": "sha1-dDh2RzDsfvQ4HOTfgvuYpTFCo/w=",
           "dev": true,
           "requires": {
@@ -13116,7 +13116,7 @@
         },
         "write-file-atomic": {
           "version": "2.4.3",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
           "integrity": "sha1-H9Lprh3z51uNjDZ0Q8aS1MqB9IE=",
           "dev": true,
           "requires": {
@@ -13127,13 +13127,13 @@
         },
         "xdg-basedir": {
           "version": "3.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
           "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
           "dev": true
         },
         "yallist": {
           "version": "2.1.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/yallist/-/yallist-2.1.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/yallist/-/yallist-2.1.2.tgz",
           "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
           "dev": true
         }
@@ -13141,7 +13141,7 @@
     },
     "sw-toolbox": {
       "version": "3.6.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/sw-toolbox/-/sw-toolbox-3.6.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/sw-toolbox/-/sw-toolbox-3.6.0.tgz",
       "integrity": "sha1-Jt8dHHA0hljk3qKIQxkUm3sxg7U=",
       "dev": true,
       "requires": {
@@ -13151,7 +13151,7 @@
       "dependencies": {
         "path-to-regexp": {
           "version": "1.8.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
           "integrity": "sha1-iHs7qdhDk+h6CgufTLdWGYtTVIo=",
           "dev": true,
           "requires": {
@@ -13162,19 +13162,19 @@
     },
     "symbol-observable": {
       "version": "1.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/symbol-observable/-/symbol-observable-1.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/symbol-observable/-/symbol-observable-1.2.0.tgz",
       "integrity": "sha1-wiaIrtTqs83C3+rLtWFmBWCgCAQ=",
       "dev": true
     },
     "symbol-tree": {
       "version": "3.2.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha1-QwY30ki6d+B4iDlR+5qg7tfGP6I=",
       "dev": true
     },
     "table": {
       "version": "5.4.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/table/-/table-5.4.6.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/table/-/table-5.4.6.tgz",
       "integrity": "sha1-EpLRlQDOP4YFOwXw6Ofko7shB54=",
       "dev": true,
       "requires": {
@@ -13186,25 +13186,25 @@
       "dependencies": {
         "ansi-regex": {
           "version": "4.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-4.1.0.tgz",
           "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc=",
           "dev": true
         },
         "emoji-regex": {
           "version": "7.0.3",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/emoji-regex/-/emoji-regex-7.0.3.tgz",
           "integrity": "sha1-kzoEBShgyF6DwSJHnEdIqOTHIVY=",
           "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
         "string-width": {
           "version": "3.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string-width/-/string-width-3.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/string-width/-/string-width-3.1.0.tgz",
           "integrity": "sha1-InZ74htirxCBV0MG9prFG2IgOWE=",
           "dev": true,
           "requires": {
@@ -13215,7 +13215,7 @@
         },
         "strip-ansi": {
           "version": "5.2.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
           "dev": true,
           "requires": {
@@ -13226,7 +13226,7 @@
     },
     "table-layout": {
       "version": "0.4.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/table-layout/-/table-layout-0.4.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/table-layout/-/table-layout-0.4.5.tgz",
       "integrity": "sha1-2QbeaiX6CcDJDR0I7Ngz7O3Lc3g=",
       "dev": true,
       "requires": {
@@ -13239,7 +13239,7 @@
       "dependencies": {
         "array-back": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/array-back/-/array-back-2.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/array-back/-/array-back-2.0.0.tgz",
           "integrity": "sha1-aHdHHVHsycm/phNvtsfV/ml0gCI=",
           "dev": true,
           "requires": {
@@ -13248,7 +13248,7 @@
         },
         "typical": {
           "version": "2.6.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/typical/-/typical-2.6.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/typical/-/typical-2.6.1.tgz",
           "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0=",
           "dev": true
         }
@@ -13256,7 +13256,7 @@
     },
     "tar": {
       "version": "2.2.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/tar/-/tar-2.2.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/tar/-/tar-2.2.2.tgz",
       "integrity": "sha1-DKiEhWLHKZuLRG/2pNYM27I+3EA=",
       "dev": true,
       "requires": {
@@ -13267,7 +13267,7 @@
     },
     "tar-stream": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/tar-stream/-/tar-stream-2.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/tar-stream/-/tar-stream-2.0.0.tgz",
       "integrity": "sha1-iCm7+DBnvAKIqQidtJxWvjlbauo=",
       "dev": true,
       "optional": true,
@@ -13281,7 +13281,7 @@
       "dependencies": {
         "readable-stream": {
           "version": "3.6.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/readable-stream/-/readable-stream-3.6.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/readable-stream/-/readable-stream-3.6.0.tgz",
           "integrity": "sha1-M3u9o63AcGvT4CRCaihtS0sskZg=",
           "dev": true,
           "optional": true,
@@ -13293,14 +13293,14 @@
         },
         "safe-buffer": {
           "version": "5.2.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/safe-buffer/-/safe-buffer-5.2.1.tgz",
           "integrity": "sha1-Hq+fqb2x/dTsdfWPnNtOa3gn7sY=",
           "dev": true,
           "optional": true
         },
         "string_decoder": {
           "version": "1.3.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string_decoder/-/string_decoder-1.3.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/string_decoder/-/string_decoder-1.3.0.tgz",
           "integrity": "sha1-QvEUWUpGzxqOMLCoT1bHjD7awh4=",
           "dev": true,
           "optional": true,
@@ -13312,7 +13312,7 @@
     },
     "tcp-port-used": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/tcp-port-used/-/tcp-port-used-1.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/tcp-port-used/-/tcp-port-used-1.0.1.tgz",
       "integrity": "sha1-RgYQeOLTjHOXmiwsErWmdOZonXA=",
       "dev": true,
       "requires": {
@@ -13322,7 +13322,7 @@
       "dependencies": {
         "debug": {
           "version": "4.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-4.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/debug/-/debug-4.1.0.tgz",
           "integrity": "sha1-NzaHv/pnizixzZH4YbY4UANd3Ic=",
           "dev": true,
           "requires": {
@@ -13331,7 +13331,7 @@
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.1.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ms/-/ms-2.1.2.tgz",
           "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
           "dev": true
         }
@@ -13339,7 +13339,7 @@
     },
     "temp": {
       "version": "0.8.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/temp/-/temp-0.8.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/temp/-/temp-0.8.4.tgz",
       "integrity": "sha1-jJejOkdwBy4KBfkZOWx2ZafdWfI=",
       "dev": true,
       "optional": true,
@@ -13349,7 +13349,7 @@
       "dependencies": {
         "rimraf": {
           "version": "2.6.3",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/rimraf/-/rimraf-2.6.3.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/rimraf/-/rimraf-2.6.3.tgz",
           "integrity": "sha1-stEE/g2Psnz54KHNqCYt04M8bKs=",
           "dev": true,
           "optional": true,
@@ -13361,13 +13361,13 @@
     },
     "term-size": {
       "version": "2.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/term-size/-/term-size-2.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/term-size/-/term-size-2.2.0.tgz",
       "integrity": "sha1-Hxat7f6b3BiADhd2ghc0CG/MZ1M=",
       "dev": true
     },
     "terminal-link": {
       "version": "2.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/terminal-link/-/terminal-link-2.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/terminal-link/-/terminal-link-2.1.1.tgz",
       "integrity": "sha1-FKZKJ6s8Dfkz6lRvulXy0HjtyZQ=",
       "dev": true,
       "requires": {
@@ -13377,7 +13377,7 @@
     },
     "ternary-stream": {
       "version": "2.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ternary-stream/-/ternary-stream-2.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ternary-stream/-/ternary-stream-2.1.1.tgz",
       "integrity": "sha1-StZLmGaNeWoIWvLEk4haQ1qKi/w=",
       "dev": true,
       "requires": {
@@ -13389,7 +13389,7 @@
       "dependencies": {
         "merge-stream": {
           "version": "1.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/merge-stream/-/merge-stream-1.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/merge-stream/-/merge-stream-1.0.1.tgz",
           "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
           "dev": true,
           "requires": {
@@ -13411,31 +13411,31 @@
     },
     "text-encoding": {
       "version": "0.6.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/text-encoding/-/text-encoding-0.6.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/text-encoding/-/text-encoding-0.6.4.tgz",
       "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
       "dev": true
     },
     "text-hex": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/text-hex/-/text-hex-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/text-hex/-/text-hex-1.0.0.tgz",
       "integrity": "sha1-adycGxdEbueakr9biEu0uRJ1BvU=",
       "dev": true
     },
     "text-table": {
       "version": "0.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/text-table/-/text-table-0.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
     "textfit": {
       "version": "2.4.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/textfit/-/textfit-2.4.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/textfit/-/textfit-2.4.0.tgz",
       "integrity": "sha1-gMuoAGv7nD2dVSc5JXlXvdqVx5w=",
       "dev": true
     },
     "thenify": {
       "version": "3.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/thenify/-/thenify-3.3.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/thenify/-/thenify-3.3.0.tgz",
       "integrity": "sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=",
       "dev": true,
       "requires": {
@@ -13444,7 +13444,7 @@
     },
     "thenify-all": {
       "version": "1.6.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/thenify-all/-/thenify-all-1.6.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/thenify-all/-/thenify-all-1.6.0.tgz",
       "integrity": "sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=",
       "dev": true,
       "requires": {
@@ -13453,13 +13453,13 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/through/-/through-2.3.8.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
     "through2": {
       "version": "2.0.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/through2/-/through2-2.0.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/through2/-/through2-2.0.5.tgz",
       "integrity": "sha1-AcHjnrMdB8t9A6lqcIIyYLIxMs0=",
       "dev": true,
       "requires": {
@@ -13469,7 +13469,7 @@
     },
     "through2-filter": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/through2-filter/-/through2-filter-2.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/through2-filter/-/through2-filter-2.0.0.tgz",
       "integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
       "dev": true,
       "requires": {
@@ -13479,26 +13479,26 @@
     },
     "timed-out": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/timed-out/-/timed-out-2.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/timed-out/-/timed-out-2.0.0.tgz",
       "integrity": "sha1-84sK6B03R9YoAB9B2vxlKs5nHAo=",
       "dev": true
     },
     "tiny-emitter": {
       "version": "2.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
       "integrity": "sha1-HRpW7fxRxD6GPLtTgqcjMONVVCM=",
       "dev": true,
       "optional": true
     },
     "tlds": {
       "version": "1.207.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/tlds/-/tlds-1.207.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/tlds/-/tlds-1.207.0.tgz",
       "integrity": "sha1-RZJk5kTPY93All/s44mJEyhrGv0=",
       "dev": true
     },
     "tmp": {
       "version": "0.0.33",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/tmp/-/tmp-0.0.33.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/tmp/-/tmp-0.0.33.tgz",
       "integrity": "sha1-bTQzWIl2jSGyvNoKonfO07G/rfk=",
       "dev": true,
       "requires": {
@@ -13507,7 +13507,7 @@
     },
     "to-absolute-glob": {
       "version": "0.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/to-absolute-glob/-/to-absolute-glob-0.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/to-absolute-glob/-/to-absolute-glob-0.1.1.tgz",
       "integrity": "sha1-HN+kcqnvUMI57maZm2YsoOs5k38=",
       "dev": true,
       "requires": {
@@ -13516,7 +13516,7 @@
       "dependencies": {
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
@@ -13527,19 +13527,19 @@
     },
     "to-array": {
       "version": "0.1.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/to-array/-/to-array-0.1.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/to-array/-/to-array-0.1.4.tgz",
       "integrity": "sha1-F+bBH3PdTz10zaek/zI46a2b+JA=",
       "dev": true
     },
     "to-fast-properties": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
       "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
       "dev": true
     },
     "to-object-path": {
       "version": "0.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/to-object-path/-/to-object-path-0.3.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/to-object-path/-/to-object-path-0.3.0.tgz",
       "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
       "dev": true,
       "requires": {
@@ -13548,13 +13548,13 @@
       "dependencies": {
         "is-buffer": {
           "version": "1.1.6",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-buffer/-/is-buffer-1.1.6.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-buffer/-/is-buffer-1.1.6.tgz",
           "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
           "dev": true
         },
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/kind-of/-/kind-of-3.2.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
@@ -13565,13 +13565,13 @@
     },
     "to-readable-stream": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
       "integrity": "sha1-zgqgwvPfat+FLvtASng+d8BHV3E=",
       "dev": true
     },
     "to-regex": {
       "version": "3.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/to-regex/-/to-regex-3.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/to-regex/-/to-regex-3.0.2.tgz",
       "integrity": "sha1-E8/dmzNlUvMLUfM6iuG0Knp1mc4=",
       "dev": true,
       "requires": {
@@ -13583,7 +13583,7 @@
     },
     "to-regex-range": {
       "version": "5.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha1-FkjESq58jZiKMmAY7XL1tN0DkuQ=",
       "dev": true,
       "requires": {
@@ -13592,13 +13592,13 @@
     },
     "toidentifier": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/toidentifier/-/toidentifier-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/toidentifier/-/toidentifier-1.0.0.tgz",
       "integrity": "sha1-fhvjRw8ed5SLxD2Uo8j013UrpVM=",
       "dev": true
     },
     "tough-cookie": {
       "version": "2.5.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/tough-cookie/-/tough-cookie-2.5.0.tgz",
       "integrity": "sha1-zZ+yoKodWhK0c72fuW+j3P9lreI=",
       "dev": true,
       "requires": {
@@ -13608,7 +13608,7 @@
     },
     "tr46": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/tr46/-/tr46-1.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/tr46/-/tr46-1.0.1.tgz",
       "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
       "dev": true,
       "requires": {
@@ -13617,43 +13617,43 @@
     },
     "trim-newlines": {
       "version": "3.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/trim-newlines/-/trim-newlines-3.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/trim-newlines/-/trim-newlines-3.0.0.tgz",
       "integrity": "sha1-eXJjBKaomKqDc0JymNVMLuixyzA=",
       "dev": true
     },
     "trim-right": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/trim-right/-/trim-right-1.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/trim-right/-/trim-right-1.0.1.tgz",
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
       "dev": true
     },
     "triple-beam": {
       "version": "1.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/triple-beam/-/triple-beam-1.3.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/triple-beam/-/triple-beam-1.3.0.tgz",
       "integrity": "sha1-pZUhTHKY24M57u7gg+TRC9jLjdk=",
       "dev": true
     },
     "try-catch": {
       "version": "3.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/try-catch/-/try-catch-3.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/try-catch/-/try-catch-3.0.0.tgz",
       "integrity": "sha1-eZbYuJiV4uiuYsvb60/hdHD4Exs=",
       "dev": true
     },
     "try-to-catch": {
       "version": "3.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/try-to-catch/-/try-to-catch-3.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/try-to-catch/-/try-to-catch-3.0.0.tgz",
       "integrity": "sha1-oZA7RNE9USTFTRSkYdIuwfUuoUs=",
       "dev": true
     },
     "tslib": {
       "version": "1.13.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/tslib/-/tslib-1.13.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/tslib/-/tslib-1.13.0.tgz",
       "integrity": "sha1-yIHhPMcBWJTtkUhi0nZDb6mkcEM=",
       "dev": true
     },
     "ttf2eot": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ttf2eot/-/ttf2eot-2.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ttf2eot/-/ttf2eot-2.0.0.tgz",
       "integrity": "sha1-jmM3pYWr0WCKDISVirSDzmn2ZUs=",
       "dev": true,
       "requires": {
@@ -13663,7 +13663,7 @@
     },
     "ttf2woff": {
       "version": "2.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ttf2woff/-/ttf2woff-2.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ttf2woff/-/ttf2woff-2.0.2.tgz",
       "integrity": "sha1-CafO5Zq9PBUoK1fthKx8d3B0nx8=",
       "dev": true,
       "requires": {
@@ -13674,7 +13674,7 @@
     },
     "ttf2woff2": {
       "version": "2.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ttf2woff2/-/ttf2woff2-2.0.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ttf2woff2/-/ttf2woff2-2.0.3.tgz",
       "integrity": "sha1-XgIK/m5kMofzrXaHq+0g/mVOsyk=",
       "dev": true,
       "requires": {
@@ -13686,7 +13686,7 @@
     },
     "tunnel-agent": {
       "version": "0.6.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "dev": true,
       "requires": {
@@ -13695,13 +13695,13 @@
     },
     "tweetnacl": {
       "version": "0.14.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "dev": true
     },
     "type-check": {
       "version": "0.4.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/type-check/-/type-check-0.4.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/type-check/-/type-check-0.4.0.tgz",
       "integrity": "sha1-B7ggO/pwVsBlcFDjzNLDdzC6uPE=",
       "dev": true,
       "requires": {
@@ -13710,19 +13710,19 @@
     },
     "type-detect": {
       "version": "4.0.8",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/type-detect/-/type-detect-4.0.8.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/type-detect/-/type-detect-4.0.8.tgz",
       "integrity": "sha1-dkb7XxiHHPu3dJ5pvTmmOI63RQw=",
       "dev": true
     },
     "type-fest": {
       "version": "0.8.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/type-fest/-/type-fest-0.8.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/type-fest/-/type-fest-0.8.1.tgz",
       "integrity": "sha1-CeJJ696FHTseSNJ8EFREZn8XuD0=",
       "dev": true
     },
     "type-is": {
       "version": "1.6.18",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/type-is/-/type-is-1.6.18.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/type-is/-/type-is-1.6.18.tgz",
       "integrity": "sha1-TlUs0F3wlGfcvE73Od6J8s83wTE=",
       "dev": true,
       "requires": {
@@ -13732,13 +13732,13 @@
     },
     "typedarray": {
       "version": "0.0.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/typedarray/-/typedarray-0.0.6.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
     "typedarray-to-buffer": {
       "version": "3.1.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
       "integrity": "sha1-qX7nqf9CaRufeD/xvFES/j/KkIA=",
       "dev": true,
       "requires": {
@@ -13747,19 +13747,19 @@
     },
     "typical": {
       "version": "4.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/typical/-/typical-4.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/typical/-/typical-4.0.0.tgz",
       "integrity": "sha1-y+r/O5164eK7+vWk5vEezP3pT8Q=",
       "dev": true
     },
     "ua-parser-js": {
       "version": "0.7.21",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ua-parser-js/-/ua-parser-js-0.7.21.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ua-parser-js/-/ua-parser-js-0.7.21.tgz",
       "integrity": "sha1-hTz5zpP2QvZxdCc8w0Vlrm8wh3c=",
       "dev": true
     },
     "uglify-js": {
       "version": "3.9.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/uglify-js/-/uglify-js-3.9.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/uglify-js/-/uglify-js-3.9.4.tgz",
       "integrity": "sha1-hnQCN34EPB/HsQIlOiK2TlhiQBs=",
       "dev": true,
       "requires": {
@@ -13768,19 +13768,19 @@
     },
     "underscore": {
       "version": "1.10.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/underscore/-/underscore-1.10.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/underscore/-/underscore-1.10.2.tgz",
       "integrity": "sha1-c9aqNmjzGI5K2w8ZQ70Sz9fvqq8=",
       "dev": true
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
       "integrity": "sha1-JhmADEyCWADv3YNDr33Zkzy+KBg=",
       "dev": true
     },
     "unicode-match-property-ecmascript": {
       "version": "1.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz",
       "integrity": "sha1-jtKjJWmWG86SJ9Cc0/+7j+1fAgw=",
       "dev": true,
       "requires": {
@@ -13790,19 +13790,19 @@
     },
     "unicode-match-property-value-ecmascript": {
       "version": "1.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.2.0.tgz",
       "integrity": "sha1-DZH2AO7rMJaqlisdb8iIduZOpTE=",
       "dev": true
     },
     "unicode-property-aliases-ecmascript": {
       "version": "1.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.1.0.tgz",
       "integrity": "sha1-3Vepn2IHvt/0Yoq++5TFDblByPQ=",
       "dev": true
     },
     "union": {
       "version": "0.5.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/union/-/union-0.5.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/union/-/union-0.5.0.tgz",
       "integrity": "sha1-ssEb6E9gU4U3uEbtuboma6AJAHU=",
       "dev": true,
       "requires": {
@@ -13811,7 +13811,7 @@
     },
     "union-value": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/union-value/-/union-value-1.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/union-value/-/union-value-1.0.1.tgz",
       "integrity": "sha1-C2/nuDWuzaYcbqTU8CwUIh4QmEc=",
       "dev": true,
       "requires": {
@@ -13823,7 +13823,7 @@
     },
     "unique-stream": {
       "version": "2.3.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/unique-stream/-/unique-stream-2.3.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/unique-stream/-/unique-stream-2.3.1.tgz",
       "integrity": "sha1-xl0RDppK35psWUiygFPZqNBMvqw=",
       "dev": true,
       "requires": {
@@ -13833,7 +13833,7 @@
       "dependencies": {
         "through2-filter": {
           "version": "3.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/through2-filter/-/through2-filter-3.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/through2-filter/-/through2-filter-3.0.0.tgz",
           "integrity": "sha1-cA54bfI2fCyIzYqlvkz5weeDElQ=",
           "dev": true,
           "requires": {
@@ -13845,7 +13845,7 @@
     },
     "unique-string": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/unique-string/-/unique-string-2.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/unique-string/-/unique-string-2.0.0.tgz",
       "integrity": "sha1-OcZFH4GvsnSd4rIz4/fF6IQ72J0=",
       "dev": true,
       "requires": {
@@ -13854,13 +13854,13 @@
     },
     "unpipe": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/unpipe/-/unpipe-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
       "dev": true
     },
     "unset-value": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/unset-value/-/unset-value-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/unset-value/-/unset-value-1.0.0.tgz",
       "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
       "dev": true,
       "requires": {
@@ -13870,7 +13870,7 @@
       "dependencies": {
         "has-value": {
           "version": "0.3.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/has-value/-/has-value-0.3.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/has-value/-/has-value-0.3.1.tgz",
           "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
           "dev": true,
           "requires": {
@@ -13881,7 +13881,7 @@
           "dependencies": {
             "isobject": {
               "version": "2.1.0",
-              "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/isobject/-/isobject-2.1.0.tgz",
+              "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/isobject/-/isobject-2.1.0.tgz",
               "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
               "dev": true,
               "requires": {
@@ -13892,13 +13892,13 @@
         },
         "has-values": {
           "version": "0.1.4",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/has-values/-/has-values-0.1.4.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/has-values/-/has-values-0.1.4.tgz",
           "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
           "dev": true
         },
         "isarray": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/isarray/-/isarray-1.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true
         }
@@ -13906,7 +13906,7 @@
     },
     "untildify": {
       "version": "2.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/untildify/-/untildify-2.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/untildify/-/untildify-2.1.0.tgz",
       "integrity": "sha1-F+soB5h/dpUunASF/DEdBqgmouA=",
       "dev": true,
       "requires": {
@@ -13915,13 +13915,13 @@
     },
     "unzip-response": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/unzip-response/-/unzip-response-1.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/unzip-response/-/unzip-response-1.0.2.tgz",
       "integrity": "sha1-uYTwh3/AqJwsdzzB73tbIytbBv4=",
       "dev": true
     },
     "update-notifier": {
       "version": "4.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/update-notifier/-/update-notifier-4.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/update-notifier/-/update-notifier-4.1.0.tgz",
       "integrity": "sha1-SGa5jDvFtUc8AgsSUFg2KPmjKPM=",
       "dev": true,
       "requires": {
@@ -13942,7 +13942,7 @@
       "dependencies": {
         "ansi-styles": {
           "version": "4.2.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-styles/-/ansi-styles-4.2.1.tgz",
           "integrity": "sha1-kK51xCTQCNJiTFvynq0xd+v881k=",
           "dev": true,
           "requires": {
@@ -13952,7 +13952,7 @@
         },
         "chalk": {
           "version": "3.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/chalk/-/chalk-3.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/chalk/-/chalk-3.0.0.tgz",
           "integrity": "sha1-P3PCv1JlkfV0zEksUeJFY0n4ROQ=",
           "dev": true,
           "requires": {
@@ -13962,7 +13962,7 @@
         },
         "color-convert": {
           "version": "2.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/color-convert/-/color-convert-2.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/color-convert/-/color-convert-2.0.1.tgz",
           "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
           "dev": true,
           "requires": {
@@ -13971,19 +13971,19 @@
         },
         "color-name": {
           "version": "1.1.4",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/color-name/-/color-name-1.1.4.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
           "dev": true
         },
         "has-flag": {
           "version": "4.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/has-flag/-/has-flag-4.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
           "dev": true
         },
         "supports-color": {
           "version": "7.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/supports-color/-/supports-color-7.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/supports-color/-/supports-color-7.1.0.tgz",
           "integrity": "sha1-aOMlkd9z4lrRxLSRCKLsUHliv9E=",
           "dev": true,
           "requires": {
@@ -13994,13 +13994,13 @@
     },
     "upper-case": {
       "version": "1.1.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/upper-case/-/upper-case-1.1.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/upper-case/-/upper-case-1.1.3.tgz",
       "integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg=",
       "dev": true
     },
     "uri-js": {
       "version": "4.2.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/uri-js/-/uri-js-4.2.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/uri-js/-/uri-js-4.2.2.tgz",
       "integrity": "sha1-lMVA4f93KVbiKZUHwBCupsiDjrA=",
       "dev": true,
       "requires": {
@@ -14009,25 +14009,25 @@
     },
     "urijs": {
       "version": "1.19.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/urijs/-/urijs-1.19.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/urijs/-/urijs-1.19.2.tgz",
       "integrity": "sha1-+b4J8AxMUTS3yzz0dcHdOUUmJlo=",
       "dev": true
     },
     "urix": {
       "version": "0.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/urix/-/urix-0.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/urix/-/urix-0.1.0.tgz",
       "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
       "dev": true
     },
     "url-join": {
       "version": "1.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/url-join/-/url-join-1.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/url-join/-/url-join-1.1.0.tgz",
       "integrity": "sha1-dBxsL0WWxIMNZxhGCSDQySIC3Hg=",
       "dev": true
     },
     "url-parse-lax": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
       "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
       "dev": true,
       "requires": {
@@ -14036,7 +14036,7 @@
     },
     "url-regex": {
       "version": "5.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/url-regex/-/url-regex-5.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/url-regex/-/url-regex-5.0.0.tgz",
       "integrity": "sha1-j1RWq4PYmNGLL5F1OnAmSbhzJzo=",
       "dev": true,
       "requires": {
@@ -14046,7 +14046,7 @@
       "dependencies": {
         "ip-regex": {
           "version": "4.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ip-regex/-/ip-regex-4.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ip-regex/-/ip-regex-4.1.0.tgz",
           "integrity": "sha1-WtYvaFoU7bQhq+vC//jblN9ntFU=",
           "dev": true
         }
@@ -14054,13 +14054,13 @@
     },
     "use": {
       "version": "3.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/use/-/use-3.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/use/-/use-3.1.1.tgz",
       "integrity": "sha1-1QyMrHmhn7wg8pEfVuuXP04QBw8=",
       "dev": true
     },
     "util": {
       "version": "0.12.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/util/-/util-0.12.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/util/-/util-0.12.3.tgz",
       "integrity": "sha1-lxuwKS0swMiS2rfGpdN8K+xweIg=",
       "dev": true,
       "requires": {
@@ -14074,37 +14074,37 @@
     },
     "util-deprecate": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
     },
     "utils-merge": {
       "version": "1.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/utils-merge/-/utils-merge-1.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
       "dev": true
     },
     "uuid": {
       "version": "3.4.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/uuid/-/uuid-3.4.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/uuid/-/uuid-3.4.0.tgz",
       "integrity": "sha1-sj5DWK+oogL+ehAK8fX4g/AgB+4=",
       "dev": true
     },
     "v8-compile-cache": {
       "version": "2.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/v8-compile-cache/-/v8-compile-cache-2.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/v8-compile-cache/-/v8-compile-cache-2.1.1.tgz",
       "integrity": "sha1-VLw83UMxe8qR413K8wWxpyN950U=",
       "dev": true
     },
     "vali-date": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vali-date/-/vali-date-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vali-date/-/vali-date-1.0.0.tgz",
       "integrity": "sha1-G5BKWWCfsyjvB4E4Qgk09rhnCaY=",
       "dev": true
     },
     "validate-npm-package-license": {
       "version": "3.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
       "integrity": "sha1-/JH2uce6FchX9MssXe/uw51PQQo=",
       "dev": true,
       "requires": {
@@ -14114,7 +14114,7 @@
     },
     "validate-npm-package-name": {
       "version": "3.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
       "integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
       "dev": true,
       "requires": {
@@ -14123,13 +14123,13 @@
     },
     "vargs": {
       "version": "0.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vargs/-/vargs-0.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vargs/-/vargs-0.1.0.tgz",
       "integrity": "sha1-a2GE2mUgzDIEzhtAfKwm2SYJ6/8=",
       "dev": true
     },
     "varstream": {
       "version": "0.3.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/varstream/-/varstream-0.3.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/varstream/-/varstream-0.3.2.tgz",
       "integrity": "sha1-GKxklHZfP/GjWtmkvgU77BiKXeE=",
       "dev": true,
       "requires": {
@@ -14138,7 +14138,7 @@
       "dependencies": {
         "readable-stream": {
           "version": "1.1.14",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/readable-stream/-/readable-stream-1.1.14.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
@@ -14152,13 +14152,13 @@
     },
     "vary": {
       "version": "1.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vary/-/vary-1.1.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vary/-/vary-1.1.2.tgz",
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
       "dev": true
     },
     "verror": {
       "version": "1.10.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/verror/-/verror-1.10.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "dev": true,
       "requires": {
@@ -14169,7 +14169,7 @@
     },
     "vinyl": {
       "version": "1.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vinyl/-/vinyl-1.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vinyl/-/vinyl-1.2.0.tgz",
       "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
       "dev": true,
       "requires": {
@@ -14180,7 +14180,7 @@
       "dependencies": {
         "clone": {
           "version": "1.0.4",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/clone/-/clone-1.0.4.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/clone/-/clone-1.0.4.tgz",
           "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
           "dev": true
         }
@@ -14188,7 +14188,7 @@
     },
     "vinyl-fs": {
       "version": "2.4.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
       "integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
       "dev": true,
       "requires": {
@@ -14213,7 +14213,7 @@
       "dependencies": {
         "merge-stream": {
           "version": "1.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/merge-stream/-/merge-stream-1.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/merge-stream/-/merge-stream-1.0.1.tgz",
           "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
           "dev": true,
           "requires": {
@@ -14337,25 +14337,25 @@
     },
     "vlq": {
       "version": "0.2.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vlq/-/vlq-0.2.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vlq/-/vlq-0.2.3.tgz",
       "integrity": "sha1-jz5DKM9jsVQMDWfhsneDhviXWyY=",
       "dev": true
     },
     "vscode-uri": {
       "version": "1.0.6",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vscode-uri/-/vscode-uri-1.0.6.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vscode-uri/-/vscode-uri-1.0.6.tgz",
       "integrity": "sha1-a48UGwu8RK17B+lPgvForHYIrU0=",
       "dev": true
     },
     "vue": {
       "version": "2.6.11",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vue/-/vue-2.6.11.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vue/-/vue-2.6.11.tgz",
       "integrity": "sha1-dllNh31LEiNEBuhONSdcbVFBJcU=",
       "dev": true
     },
     "w3c-hr-time": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz",
       "integrity": "sha1-ConN9cwVgi35w2BUNnaWPgzDCM0=",
       "dev": true,
       "requires": {
@@ -14364,7 +14364,7 @@
     },
     "w3c-xmlserializer": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/w3c-xmlserializer/-/w3c-xmlserializer-2.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/w3c-xmlserializer/-/w3c-xmlserializer-2.0.0.tgz",
       "integrity": "sha1-PnEEoFt1FGzGD1ZDgLf2g6zxAgo=",
       "dev": true,
       "requires": {
@@ -14373,7 +14373,7 @@
     },
     "wbuf": {
       "version": "1.7.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/wbuf/-/wbuf-1.7.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/wbuf/-/wbuf-1.7.3.tgz",
       "integrity": "sha1-wdjRSTFtPqhShIiVy2oL/oh7h98=",
       "dev": true,
       "requires": {
@@ -14382,7 +14382,7 @@
     },
     "wct-browser-legacy": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/wct-browser-legacy/-/wct-browser-legacy-1.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/wct-browser-legacy/-/wct-browser-legacy-1.0.2.tgz",
       "integrity": "sha1-a+ORdL034pAwKNPb0ikvnE7Fl2c=",
       "dev": true,
       "requires": {
@@ -14402,19 +14402,19 @@
       "dependencies": {
         "async": {
           "version": "1.5.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/async/-/async-1.5.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/async/-/async-1.5.2.tgz",
           "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
           "dev": true
         },
         "browser-stdout": {
           "version": "1.3.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/browser-stdout/-/browser-stdout-1.3.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/browser-stdout/-/browser-stdout-1.3.0.tgz",
           "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
           "dev": true
         },
         "chai": {
           "version": "3.5.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/chai/-/chai-3.5.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/chai/-/chai-3.5.0.tgz",
           "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
           "dev": true,
           "requires": {
@@ -14425,7 +14425,7 @@
         },
         "commander": {
           "version": "2.9.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/commander/-/commander-2.9.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/commander/-/commander-2.9.0.tgz",
           "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
           "dev": true,
           "requires": {
@@ -14434,7 +14434,7 @@
         },
         "debug": {
           "version": "2.6.8",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-2.6.8.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/debug/-/debug-2.6.8.tgz",
           "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
           "dev": true,
           "requires": {
@@ -14443,7 +14443,7 @@
         },
         "deep-eql": {
           "version": "0.1.3",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/deep-eql/-/deep-eql-0.1.3.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/deep-eql/-/deep-eql-0.1.3.tgz",
           "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
           "dev": true,
           "requires": {
@@ -14452,7 +14452,7 @@
           "dependencies": {
             "type-detect": {
               "version": "0.1.1",
-              "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/type-detect/-/type-detect-0.1.1.tgz",
+              "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/type-detect/-/type-detect-0.1.1.tgz",
               "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI=",
               "dev": true
             }
@@ -14460,13 +14460,13 @@
         },
         "diff": {
           "version": "3.2.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/diff/-/diff-3.2.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/diff/-/diff-3.2.0.tgz",
           "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
           "dev": true
         },
         "glob": {
           "version": "7.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/glob/-/glob-7.1.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/glob/-/glob-7.1.1.tgz",
           "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
           "dev": true,
           "requires": {
@@ -14480,37 +14480,37 @@
         },
         "growl": {
           "version": "1.9.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/growl/-/growl-1.9.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/growl/-/growl-1.9.2.tgz",
           "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
           "dev": true
         },
         "has-flag": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/has-flag/-/has-flag-1.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/has-flag/-/has-flag-1.0.0.tgz",
           "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
           "dev": true
         },
         "he": {
           "version": "1.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/he/-/he-1.1.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/he/-/he-1.1.1.tgz",
           "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
           "dev": true
         },
         "lodash": {
           "version": "3.10.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash/-/lodash-3.10.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
           "dev": true
         },
         "minimist": {
           "version": "0.0.8",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/minimist/-/minimist-0.0.8.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         },
         "mkdirp": {
           "version": "0.5.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mkdirp/-/mkdirp-0.5.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
           "requires": {
@@ -14519,7 +14519,7 @@
         },
         "mocha": {
           "version": "3.5.3",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/mocha/-/mocha-3.5.3.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/mocha/-/mocha-3.5.3.tgz",
           "integrity": "sha1-HgSA/jbS2lhY0etqzDhBiybqog0=",
           "dev": true,
           "requires": {
@@ -14539,7 +14539,7 @@
         },
         "sinon": {
           "version": "1.17.7",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/sinon/-/sinon-1.17.7.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/sinon/-/sinon-1.17.7.tgz",
           "integrity": "sha1-RUKk9JugxFwF6y6d2dID4rjv4L8=",
           "dev": true,
           "requires": {
@@ -14551,7 +14551,7 @@
         },
         "supports-color": {
           "version": "3.1.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/supports-color/-/supports-color-3.1.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/supports-color/-/supports-color-3.1.2.tgz",
           "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
           "dev": true,
           "requires": {
@@ -14560,7 +14560,7 @@
         },
         "type-detect": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/type-detect/-/type-detect-1.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/type-detect/-/type-detect-1.0.0.tgz",
           "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI=",
           "dev": true
         }
@@ -14568,7 +14568,7 @@
     },
     "wct-local": {
       "version": "2.1.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/wct-local/-/wct-local-2.1.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/wct-local/-/wct-local-2.1.5.tgz",
       "integrity": "sha1-95hnU+OtmjXTkXipmJNQUjVh//E=",
       "dev": true,
       "optional": true,
@@ -14587,7 +14587,7 @@
       "dependencies": {
         "chalk": {
           "version": "2.4.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/chalk/-/chalk-2.4.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
           "dev": true,
           "optional": true,
@@ -14601,7 +14601,7 @@
     },
     "wct-sauce": {
       "version": "2.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/wct-sauce/-/wct-sauce-2.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/wct-sauce/-/wct-sauce-2.1.0.tgz",
       "integrity": "sha1-Z9C+NGqru8KDhOjRQ7jTynundMA=",
       "dev": true,
       "optional": true,
@@ -14617,7 +14617,7 @@
       "dependencies": {
         "chalk": {
           "version": "2.4.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/chalk/-/chalk-2.4.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
           "dev": true,
           "optional": true,
@@ -14631,7 +14631,7 @@
     },
     "wd": {
       "version": "1.12.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/wd/-/wd-1.12.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/wd/-/wd-1.12.1.tgz",
       "integrity": "sha1-Bn6zZ02wDuueUGcB+TFGV8RNWok=",
       "dev": true,
       "requires": {
@@ -14646,13 +14646,13 @@
       "dependencies": {
         "punycode": {
           "version": "1.4.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/punycode/-/punycode-1.4.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/punycode/-/punycode-1.4.1.tgz",
           "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
           "dev": true
         },
         "request": {
           "version": "2.88.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/request/-/request-2.88.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/request/-/request-2.88.0.tgz",
           "integrity": "sha1-nC/KT301tZLv5Xx/ClXoEFIST+8=",
           "dev": true,
           "requires": {
@@ -14680,7 +14680,7 @@
         },
         "tough-cookie": {
           "version": "2.4.3",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/tough-cookie/-/tough-cookie-2.4.3.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/tough-cookie/-/tough-cookie-2.4.3.tgz",
           "integrity": "sha1-U/Nto/R3g7CSWvoG/587FlKA94E=",
           "dev": true,
           "requires": {
@@ -14692,7 +14692,7 @@
     },
     "web-component-tester": {
       "version": "6.9.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/web-component-tester/-/web-component-tester-6.9.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/web-component-tester/-/web-component-tester-6.9.2.tgz",
       "integrity": "sha1-QKe4JPLPPLxDBVUr38M1eXfe1Io=",
       "dev": true,
       "requires": {
@@ -14728,19 +14728,19 @@
       "dependencies": {
         "@polymer/test-fixture": {
           "version": "0.0.3",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@polymer/test-fixture/-/test-fixture-0.0.3.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@polymer/test-fixture/-/test-fixture-0.0.3.tgz",
           "integrity": "sha1-REN1JpfU2Sk7vEEuoLXk00HxSdk=",
           "dev": true
         },
         "@webcomponents/webcomponentsjs": {
           "version": "1.3.3",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@webcomponents/webcomponentsjs/-/webcomponentsjs-1.3.3.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@webcomponents/webcomponentsjs/-/webcomponentsjs-1.3.3.tgz",
           "integrity": "sha1-W7gqDTIQyDa9RiPhOkqTFFy53Cc=",
           "dev": true
         },
         "ansi-align": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-align/-/ansi-align-2.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-align/-/ansi-align-2.0.0.tgz",
           "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
           "dev": true,
           "optional": true,
@@ -14750,20 +14750,20 @@
         },
         "ansi-regex": {
           "version": "3.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true,
           "optional": true
         },
         "ansi-styles": {
           "version": "2.2.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-styles/-/ansi-styles-2.2.1.tgz",
           "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
           "dev": true
         },
         "boxen": {
           "version": "1.3.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/boxen/-/boxen-1.3.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/boxen/-/boxen-1.3.0.tgz",
           "integrity": "sha1-VcbDmouljZxhrSLNh3Uy3rZlogs=",
           "dev": true,
           "optional": true,
@@ -14779,7 +14779,7 @@
           "dependencies": {
             "ansi-styles": {
               "version": "3.2.1",
-              "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-styles/-/ansi-styles-3.2.1.tgz",
+              "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-styles/-/ansi-styles-3.2.1.tgz",
               "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
               "dev": true,
               "optional": true,
@@ -14789,7 +14789,7 @@
             },
             "chalk": {
               "version": "2.4.2",
-              "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/chalk/-/chalk-2.4.2.tgz",
+              "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/chalk/-/chalk-2.4.2.tgz",
               "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
               "dev": true,
               "optional": true,
@@ -14801,7 +14801,7 @@
             },
             "supports-color": {
               "version": "5.5.0",
-              "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/supports-color/-/supports-color-5.5.0.tgz",
+              "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/supports-color/-/supports-color-5.5.0.tgz",
               "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
               "dev": true,
               "optional": true,
@@ -14813,14 +14813,14 @@
         },
         "camelcase": {
           "version": "4.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/camelcase/-/camelcase-4.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/camelcase/-/camelcase-4.1.0.tgz",
           "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
           "dev": true,
           "optional": true
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -14833,21 +14833,21 @@
         },
         "ci-info": {
           "version": "1.6.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ci-info/-/ci-info-1.6.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ci-info/-/ci-info-1.6.0.tgz",
           "integrity": "sha1-LKINu5zrMtRSSmgzAzE/AwSx5Jc=",
           "dev": true,
           "optional": true
         },
         "cli-boxes": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cli-boxes/-/cli-boxes-1.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/cli-boxes/-/cli-boxes-1.0.0.tgz",
           "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
           "dev": true,
           "optional": true
         },
         "configstore": {
           "version": "3.1.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/configstore/-/configstore-3.1.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/configstore/-/configstore-3.1.2.tgz",
           "integrity": "sha1-xvJd767vJt8S3TNBSwAf6BpUP48=",
           "dev": true,
           "optional": true,
@@ -14862,7 +14862,7 @@
         },
         "cross-spawn": {
           "version": "5.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cross-spawn/-/cross-spawn-5.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/cross-spawn/-/cross-spawn-5.1.0.tgz",
           "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
           "dev": true,
           "optional": true,
@@ -14874,14 +14874,14 @@
         },
         "crypto-random-string": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
           "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
           "dev": true,
           "optional": true
         },
         "dot-prop": {
           "version": "4.2.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/dot-prop/-/dot-prop-4.2.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/dot-prop/-/dot-prop-4.2.0.tgz",
           "integrity": "sha1-HxngwuGqDjJ5fEl5nyg3rGr2nFc=",
           "dev": true,
           "optional": true,
@@ -14891,7 +14891,7 @@
         },
         "execa": {
           "version": "0.7.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/execa/-/execa-0.7.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/execa/-/execa-0.7.0.tgz",
           "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
           "dev": true,
           "optional": true,
@@ -14907,7 +14907,7 @@
         },
         "formatio": {
           "version": "1.2.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/formatio/-/formatio-1.2.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/formatio/-/formatio-1.2.0.tgz",
           "integrity": "sha1-87IWfZBoxGmKjVH092CjmlTYGOs=",
           "dev": true,
           "requires": {
@@ -14916,14 +14916,14 @@
         },
         "get-stream": {
           "version": "3.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/get-stream/-/get-stream-3.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/get-stream/-/get-stream-3.0.0.tgz",
           "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
           "dev": true,
           "optional": true
         },
         "global-dirs": {
           "version": "0.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/global-dirs/-/global-dirs-0.1.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/global-dirs/-/global-dirs-0.1.1.tgz",
           "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
           "dev": true,
           "optional": true,
@@ -14933,7 +14933,7 @@
         },
         "got": {
           "version": "6.7.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/got/-/got-6.7.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/got/-/got-6.7.1.tgz",
           "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
           "dev": true,
           "optional": true,
@@ -14953,7 +14953,7 @@
         },
         "is-ci": {
           "version": "1.2.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-ci/-/is-ci-1.2.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-ci/-/is-ci-1.2.1.tgz",
           "integrity": "sha1-43ecjuF/zPQoSI9uKBGH8uYyhBw=",
           "dev": true,
           "optional": true,
@@ -14963,14 +14963,14 @@
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true,
           "optional": true
         },
         "is-installed-globally": {
           "version": "0.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
           "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
           "dev": true,
           "optional": true,
@@ -14981,21 +14981,21 @@
         },
         "is-npm": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-npm/-/is-npm-1.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-npm/-/is-npm-1.0.0.tgz",
           "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
           "dev": true,
           "optional": true
         },
         "is-obj": {
           "version": "1.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-obj/-/is-obj-1.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-obj/-/is-obj-1.0.1.tgz",
           "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
           "dev": true,
           "optional": true
         },
         "is-path-inside": {
           "version": "1.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-path-inside/-/is-path-inside-1.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-path-inside/-/is-path-inside-1.0.1.tgz",
           "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
           "dev": true,
           "optional": true,
@@ -15005,7 +15005,7 @@
         },
         "latest-version": {
           "version": "3.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/latest-version/-/latest-version-3.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/latest-version/-/latest-version-3.1.0.tgz",
           "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
           "dev": true,
           "optional": true,
@@ -15015,19 +15015,19 @@
         },
         "lodash": {
           "version": "3.10.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lodash/-/lodash-3.10.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
           "dev": true
         },
         "lolex": {
           "version": "1.6.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lolex/-/lolex-1.6.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lolex/-/lolex-1.6.0.tgz",
           "integrity": "sha1-OpoCg0UqR9dDnnJzG54H1zhuSfY=",
           "dev": true
         },
         "lru-cache": {
           "version": "4.1.5",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lru-cache/-/lru-cache-4.1.5.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lru-cache/-/lru-cache-4.1.5.tgz",
           "integrity": "sha1-i75Q6oW+1ZvJ4z3KuCNe6bz0Q80=",
           "dev": true,
           "optional": true,
@@ -15038,7 +15038,7 @@
         },
         "make-dir": {
           "version": "1.3.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/make-dir/-/make-dir-1.3.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/make-dir/-/make-dir-1.3.0.tgz",
           "integrity": "sha1-ecEDO4BRW9bSTsmTPoYMp17ifww=",
           "dev": true,
           "optional": true,
@@ -15048,7 +15048,7 @@
         },
         "npm-run-path": {
           "version": "2.0.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/npm-run-path/-/npm-run-path-2.0.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/npm-run-path/-/npm-run-path-2.0.2.tgz",
           "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
           "dev": true,
           "optional": true,
@@ -15058,7 +15058,7 @@
         },
         "package-json": {
           "version": "4.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/package-json/-/package-json-4.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/package-json/-/package-json-4.0.1.tgz",
           "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
           "dev": true,
           "optional": true,
@@ -15071,14 +15071,14 @@
         },
         "path-key": {
           "version": "2.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/path-key/-/path-key-2.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/path-key/-/path-key-2.0.1.tgz",
           "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
           "dev": true,
           "optional": true
         },
         "path-to-regexp": {
           "version": "1.8.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
           "integrity": "sha1-iHs7qdhDk+h6CgufTLdWGYtTVIo=",
           "dev": true,
           "requires": {
@@ -15087,14 +15087,14 @@
         },
         "pify": {
           "version": "3.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/pify/-/pify-3.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/pify/-/pify-3.0.0.tgz",
           "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
           "dev": true,
           "optional": true
         },
         "registry-auth-token": {
           "version": "3.4.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/registry-auth-token/-/registry-auth-token-3.4.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/registry-auth-token/-/registry-auth-token-3.4.0.tgz",
           "integrity": "sha1-10RoFUM/XV7WQxzV3KIQSPZrOX4=",
           "dev": true,
           "optional": true,
@@ -15105,7 +15105,7 @@
         },
         "registry-url": {
           "version": "3.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/registry-url/-/registry-url-3.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/registry-url/-/registry-url-3.1.0.tgz",
           "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
           "dev": true,
           "optional": true,
@@ -15115,13 +15115,13 @@
         },
         "samsam": {
           "version": "1.3.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/samsam/-/samsam-1.3.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/samsam/-/samsam-1.3.0.tgz",
           "integrity": "sha1-jR2TUOJWItow3j5EumkrUiGrfFA=",
           "dev": true
         },
         "semver-diff": {
           "version": "2.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/semver-diff/-/semver-diff-2.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/semver-diff/-/semver-diff-2.1.0.tgz",
           "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
           "dev": true,
           "optional": true,
@@ -15131,7 +15131,7 @@
         },
         "shebang-command": {
           "version": "1.2.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/shebang-command/-/shebang-command-1.2.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/shebang-command/-/shebang-command-1.2.0.tgz",
           "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
           "dev": true,
           "optional": true,
@@ -15141,14 +15141,14 @@
         },
         "shebang-regex": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/shebang-regex/-/shebang-regex-1.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/shebang-regex/-/shebang-regex-1.0.0.tgz",
           "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
           "dev": true,
           "optional": true
         },
         "sinon": {
           "version": "2.4.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/sinon/-/sinon-2.4.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/sinon/-/sinon-2.4.1.tgz",
           "integrity": "sha1-Ah/WS1TLd9nS+w1Dze3652KcOjY=",
           "dev": true,
           "requires": {
@@ -15164,7 +15164,7 @@
         },
         "string-width": {
           "version": "2.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string-width/-/string-width-2.1.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/string-width/-/string-width-2.1.1.tgz",
           "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
           "dev": true,
           "optional": true,
@@ -15175,7 +15175,7 @@
           "dependencies": {
             "strip-ansi": {
               "version": "4.0.0",
-              "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-4.0.0.tgz",
+              "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-4.0.0.tgz",
               "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "dev": true,
               "optional": true,
@@ -15187,13 +15187,13 @@
         },
         "supports-color": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/supports-color/-/supports-color-2.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/supports-color/-/supports-color-2.0.0.tgz",
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
           "dev": true
         },
         "term-size": {
           "version": "1.2.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/term-size/-/term-size-1.2.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/term-size/-/term-size-1.2.0.tgz",
           "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
           "dev": true,
           "optional": true,
@@ -15203,14 +15203,14 @@
         },
         "timed-out": {
           "version": "4.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/timed-out/-/timed-out-4.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/timed-out/-/timed-out-4.0.1.tgz",
           "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
           "dev": true,
           "optional": true
         },
         "unique-string": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/unique-string/-/unique-string-1.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/unique-string/-/unique-string-1.0.0.tgz",
           "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
           "dev": true,
           "optional": true,
@@ -15220,14 +15220,14 @@
         },
         "unzip-response": {
           "version": "2.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/unzip-response/-/unzip-response-2.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/unzip-response/-/unzip-response-2.0.1.tgz",
           "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
           "dev": true,
           "optional": true
         },
         "update-notifier": {
           "version": "2.5.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/update-notifier/-/update-notifier-2.5.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/update-notifier/-/update-notifier-2.5.0.tgz",
           "integrity": "sha1-0HRFk+E/Fh5AassdlAi3LK0Ir/Y=",
           "dev": true,
           "optional": true,
@@ -15246,7 +15246,7 @@
           "dependencies": {
             "ansi-styles": {
               "version": "3.2.1",
-              "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-styles/-/ansi-styles-3.2.1.tgz",
+              "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-styles/-/ansi-styles-3.2.1.tgz",
               "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
               "dev": true,
               "optional": true,
@@ -15256,7 +15256,7 @@
             },
             "chalk": {
               "version": "2.4.2",
-              "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/chalk/-/chalk-2.4.2.tgz",
+              "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/chalk/-/chalk-2.4.2.tgz",
               "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
               "dev": true,
               "optional": true,
@@ -15268,7 +15268,7 @@
             },
             "supports-color": {
               "version": "5.5.0",
-              "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/supports-color/-/supports-color-5.5.0.tgz",
+              "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/supports-color/-/supports-color-5.5.0.tgz",
               "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
               "dev": true,
               "optional": true,
@@ -15280,7 +15280,7 @@
         },
         "widest-line": {
           "version": "2.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/widest-line/-/widest-line-2.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/widest-line/-/widest-line-2.0.1.tgz",
           "integrity": "sha1-dDh2RzDsfvQ4HOTfgvuYpTFCo/w=",
           "dev": true,
           "optional": true,
@@ -15290,7 +15290,7 @@
         },
         "write-file-atomic": {
           "version": "2.4.3",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
           "integrity": "sha1-H9Lprh3z51uNjDZ0Q8aS1MqB9IE=",
           "dev": true,
           "optional": true,
@@ -15302,14 +15302,14 @@
         },
         "xdg-basedir": {
           "version": "3.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
           "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
           "dev": true,
           "optional": true
         },
         "yallist": {
           "version": "2.1.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/yallist/-/yallist-2.1.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/yallist/-/yallist-2.1.2.tgz",
           "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
           "dev": true,
           "optional": true
@@ -15318,7 +15318,7 @@
     },
     "webfonts-generator": {
       "version": "0.4.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/webfonts-generator/-/webfonts-generator-0.4.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/webfonts-generator/-/webfonts-generator-0.4.0.tgz",
       "integrity": "sha1-X4n8gccWDm4Mu8m3OH5CpYUf2kY=",
       "dev": true,
       "requires": {
@@ -15336,13 +15336,13 @@
     },
     "webidl-conversions": {
       "version": "4.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
       "integrity": "sha1-qFWYCx8LazWbodXZ+zmulB+qY60=",
       "dev": true
     },
     "whatwg-encoding": {
       "version": "1.0.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
       "integrity": "sha1-WrrPd3wyFmpR0IXWtPPn0nET3bA=",
       "dev": true,
       "requires": {
@@ -15351,13 +15351,13 @@
     },
     "whatwg-mimetype": {
       "version": "2.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
       "integrity": "sha1-PUseAxLSB5h5+Cav8Y2+7KWWD78=",
       "dev": true
     },
     "whatwg-url": {
       "version": "6.5.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/whatwg-url/-/whatwg-url-6.5.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/whatwg-url/-/whatwg-url-6.5.0.tgz",
       "integrity": "sha1-8t8Cv/F2/WUHDfdK1cy7WhmZZag=",
       "dev": true,
       "requires": {
@@ -15368,7 +15368,7 @@
     },
     "which": {
       "version": "1.3.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/which/-/which-1.3.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/which/-/which-1.3.1.tgz",
       "integrity": "sha1-pFBD1U9YBTFtqNYvn1CRjT2nCwo=",
       "dev": true,
       "requires": {
@@ -15377,13 +15377,13 @@
     },
     "which-module": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/which-module/-/which-module-2.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true
     },
     "which-typed-array": {
       "version": "1.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/which-typed-array/-/which-typed-array-1.1.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/which-typed-array/-/which-typed-array-1.1.2.tgz",
       "integrity": "sha1-5fmOVr2pPj2sGWsB1HwRVmecALI=",
       "dev": true,
       "requires": {
@@ -15397,7 +15397,7 @@
     },
     "wide-align": {
       "version": "1.1.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/wide-align/-/wide-align-1.1.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/wide-align/-/wide-align-1.1.3.tgz",
       "integrity": "sha1-rgdOa9wMFKQx6ATmJFScYzsABFc=",
       "dev": true,
       "requires": {
@@ -15406,7 +15406,7 @@
     },
     "widest-line": {
       "version": "3.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/widest-line/-/widest-line-3.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/widest-line/-/widest-line-3.1.0.tgz",
       "integrity": "sha1-gpIzO79my0X/DeFgOxNreuFJbso=",
       "dev": true,
       "requires": {
@@ -15415,19 +15415,19 @@
       "dependencies": {
         "ansi-regex": {
           "version": "5.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-5.0.0.tgz",
           "integrity": "sha1-OIU59VF5vzkznIGvMKZU1p+Hy3U=",
           "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "3.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
           "integrity": "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0=",
           "dev": true
         },
         "string-width": {
           "version": "4.2.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string-width/-/string-width-4.2.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/string-width/-/string-width-4.2.0.tgz",
           "integrity": "sha1-lSGCxGzHssMT0VluYjmSvRY7crU=",
           "dev": true,
           "requires": {
@@ -15438,7 +15438,7 @@
         },
         "strip-ansi": {
           "version": "6.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-6.0.0.tgz",
           "integrity": "sha1-CxVx3XZpzNTz4G4U7x7tJiJa5TI=",
           "dev": true,
           "requires": {
@@ -15449,7 +15449,7 @@
     },
     "winston": {
       "version": "3.2.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/winston/-/winston-3.2.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/winston/-/winston-3.2.1.tgz",
       "integrity": "sha1-YwYTd5dsc1hAKL4kkKGEYFX3fwc=",
       "dev": true,
       "requires": {
@@ -15466,7 +15466,7 @@
       "dependencies": {
         "logform": {
           "version": "2.1.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/logform/-/logform-2.1.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/logform/-/logform-2.1.2.tgz",
           "integrity": "sha1-lXFV6+tnoTFkBpglzmfdtbst02A=",
           "dev": true,
           "requires": {
@@ -15479,13 +15479,13 @@
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.1.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ms/-/ms-2.1.2.tgz",
           "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
           "dev": true
         },
         "readable-stream": {
           "version": "3.6.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/readable-stream/-/readable-stream-3.6.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/readable-stream/-/readable-stream-3.6.0.tgz",
           "integrity": "sha1-M3u9o63AcGvT4CRCaihtS0sskZg=",
           "dev": true,
           "requires": {
@@ -15496,13 +15496,13 @@
         },
         "safe-buffer": {
           "version": "5.2.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/safe-buffer/-/safe-buffer-5.2.1.tgz",
           "integrity": "sha1-Hq+fqb2x/dTsdfWPnNtOa3gn7sY=",
           "dev": true
         },
         "string_decoder": {
           "version": "1.3.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string_decoder/-/string_decoder-1.3.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/string_decoder/-/string_decoder-1.3.0.tgz",
           "integrity": "sha1-QvEUWUpGzxqOMLCoT1bHjD7awh4=",
           "dev": true,
           "requires": {
@@ -15513,7 +15513,7 @@
     },
     "winston-transport": {
       "version": "4.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/winston-transport/-/winston-transport-4.3.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/winston-transport/-/winston-transport-4.3.0.tgz",
       "integrity": "sha1-32jAwgJILESNm0cxPAcwTC18LGY=",
       "dev": true,
       "requires": {
@@ -15523,19 +15523,19 @@
     },
     "word-wrap": {
       "version": "1.2.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/word-wrap/-/word-wrap-1.2.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/word-wrap/-/word-wrap-1.2.3.tgz",
       "integrity": "sha1-YQY29rH3A4kb00dxzLF/uTtHB5w=",
       "dev": true
     },
     "wordwrap": {
       "version": "1.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/wordwrap/-/wordwrap-1.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
       "dev": true
     },
     "wordwrapjs": {
       "version": "3.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/wordwrapjs/-/wordwrapjs-3.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/wordwrapjs/-/wordwrapjs-3.0.0.tgz",
       "integrity": "sha1-yUw3KJTK3G/rGma/9k4dmvksXR4=",
       "dev": true,
       "requires": {
@@ -15545,7 +15545,7 @@
       "dependencies": {
         "typical": {
           "version": "2.6.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/typical/-/typical-2.6.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/typical/-/typical-2.6.1.tgz",
           "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0=",
           "dev": true
         }
@@ -15553,7 +15553,7 @@
     },
     "wrap-ansi": {
       "version": "5.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
       "integrity": "sha1-H9H2cjXVttD+54EFYAG/tpTAOwk=",
       "dev": true,
       "requires": {
@@ -15564,25 +15564,25 @@
       "dependencies": {
         "ansi-regex": {
           "version": "4.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-4.1.0.tgz",
           "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc=",
           "dev": true
         },
         "emoji-regex": {
           "version": "7.0.3",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/emoji-regex/-/emoji-regex-7.0.3.tgz",
           "integrity": "sha1-kzoEBShgyF6DwSJHnEdIqOTHIVY=",
           "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
         "string-width": {
           "version": "3.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string-width/-/string-width-3.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/string-width/-/string-width-3.1.0.tgz",
           "integrity": "sha1-InZ74htirxCBV0MG9prFG2IgOWE=",
           "dev": true,
           "requires": {
@@ -15593,7 +15593,7 @@
         },
         "strip-ansi": {
           "version": "5.2.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
           "dev": true,
           "requires": {
@@ -15604,13 +15604,13 @@
     },
     "wrappy": {
       "version": "1.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/wrappy/-/wrappy-1.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
     },
     "write": {
       "version": "1.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/write/-/write-1.0.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/write/-/write-1.0.3.tgz",
       "integrity": "sha1-CADhRSO5I6OH5BUSPIZWFqrg9cM=",
       "dev": true,
       "requires": {
@@ -15619,7 +15619,7 @@
     },
     "write-file-atomic": {
       "version": "3.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
       "integrity": "sha1-Vr1cWlxwSBzRnFcb05q5ZaXeVug=",
       "dev": true,
       "requires": {
@@ -15631,74 +15631,74 @@
     },
     "ws": {
       "version": "7.3.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ws/-/ws-7.3.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ws/-/ws-7.3.0.tgz",
       "integrity": "sha1-Sy9/IZs9Nze8Gi+/FF2CW5TTj/0=",
       "dev": true
     },
     "xdg-basedir": {
       "version": "4.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
       "integrity": "sha1-S8jZmEQDaWIl74OhVzy7y0552xM=",
       "dev": true
     },
     "xml-name-validator": {
       "version": "3.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
       "integrity": "sha1-auc+Bt5NjG5H+fsYH3jWSK1FfGo=",
       "dev": true
     },
     "xmlbuilder": {
       "version": "8.2.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/xmlbuilder/-/xmlbuilder-8.2.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/xmlbuilder/-/xmlbuilder-8.2.2.tgz",
       "integrity": "sha1-aSSGc0ELS6QuGmE2VR0pIjNap3M=",
       "dev": true,
       "optional": true
     },
     "xmlchars": {
       "version": "2.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/xmlchars/-/xmlchars-2.2.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha1-Bg/hvLf5x2/ioX24apvDq4lCEMs=",
       "dev": true
     },
     "xmldom": {
       "version": "0.1.31",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/xmldom/-/xmldom-0.1.31.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/xmldom/-/xmldom-0.1.31.tgz",
       "integrity": "sha1-t2yaG9nwqXN+WnLcNyMc84N14v8=",
       "dev": true
     },
     "xmlhttprequest-ssl": {
       "version": "1.5.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz",
       "integrity": "sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4=",
       "dev": true
     },
     "xtend": {
       "version": "4.0.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/xtend/-/xtend-4.0.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/xtend/-/xtend-4.0.2.tgz",
       "integrity": "sha1-u3J3n1+kZRhrH0OPZ0+jR/2121Q=",
       "dev": true
     },
     "y18n": {
       "version": "4.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/y18n/-/y18n-4.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/y18n/-/y18n-4.0.0.tgz",
       "integrity": "sha1-le+U+F7MgdAHwmThkKEg8KPIVms=",
       "dev": true
     },
     "yallist": {
       "version": "3.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/yallist/-/yallist-3.1.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha1-27fa+b/YusmrRev2ArjLrQ1dCP0=",
       "dev": true
     },
     "yaml": {
       "version": "1.10.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/yaml/-/yaml-1.10.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/yaml/-/yaml-1.10.0.tgz",
       "integrity": "sha1-O1k63ZRIdgd9TWg/7gEIG9n/8x4=",
       "dev": true
     },
     "yargs": {
       "version": "15.3.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/yargs/-/yargs-15.3.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/yargs/-/yargs-15.3.1.tgz",
       "integrity": "sha1-lQW0cnY5Y+VK/mAUitJ6MwgY6Ys=",
       "dev": true,
       "requires": {
@@ -15717,13 +15717,13 @@
       "dependencies": {
         "ansi-regex": {
           "version": "5.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-5.0.0.tgz",
           "integrity": "sha1-OIU59VF5vzkznIGvMKZU1p+Hy3U=",
           "dev": true
         },
         "ansi-styles": {
           "version": "4.2.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-styles/-/ansi-styles-4.2.1.tgz",
           "integrity": "sha1-kK51xCTQCNJiTFvynq0xd+v881k=",
           "dev": true,
           "requires": {
@@ -15733,7 +15733,7 @@
         },
         "cliui": {
           "version": "6.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cliui/-/cliui-6.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/cliui/-/cliui-6.0.0.tgz",
           "integrity": "sha1-UR1wLAxOQcoVbX0OlgIfI+EyJbE=",
           "dev": true,
           "requires": {
@@ -15744,7 +15744,7 @@
         },
         "color-convert": {
           "version": "2.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/color-convert/-/color-convert-2.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/color-convert/-/color-convert-2.0.1.tgz",
           "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
           "dev": true,
           "requires": {
@@ -15753,13 +15753,13 @@
         },
         "color-name": {
           "version": "1.1.4",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/color-name/-/color-name-1.1.4.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
           "dev": true
         },
         "find-up": {
           "version": "4.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/find-up/-/find-up-4.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/find-up/-/find-up-4.1.0.tgz",
           "integrity": "sha1-l6/n1s3AvFkoWEt8jXsW6KmqXRk=",
           "dev": true,
           "requires": {
@@ -15769,13 +15769,13 @@
         },
         "is-fullwidth-code-point": {
           "version": "3.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
           "integrity": "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0=",
           "dev": true
         },
         "locate-path": {
           "version": "5.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/locate-path/-/locate-path-5.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/locate-path/-/locate-path-5.0.0.tgz",
           "integrity": "sha1-Gvujlq/WdqbUJQTQpno6frn2KqA=",
           "dev": true,
           "requires": {
@@ -15784,7 +15784,7 @@
         },
         "p-locate": {
           "version": "4.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/p-locate/-/p-locate-4.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/p-locate/-/p-locate-4.1.0.tgz",
           "integrity": "sha1-o0KLtwiLOmApL2aRkni3wpetTwc=",
           "dev": true,
           "requires": {
@@ -15793,13 +15793,13 @@
         },
         "path-exists": {
           "version": "4.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/path-exists/-/path-exists-4.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/path-exists/-/path-exists-4.0.0.tgz",
           "integrity": "sha1-UTvb4tO5XXdi6METfvoZXGxhtbM=",
           "dev": true
         },
         "string-width": {
           "version": "4.2.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string-width/-/string-width-4.2.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/string-width/-/string-width-4.2.0.tgz",
           "integrity": "sha1-lSGCxGzHssMT0VluYjmSvRY7crU=",
           "dev": true,
           "requires": {
@@ -15810,7 +15810,7 @@
         },
         "strip-ansi": {
           "version": "6.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-6.0.0.tgz",
           "integrity": "sha1-CxVx3XZpzNTz4G4U7x7tJiJa5TI=",
           "dev": true,
           "requires": {
@@ -15819,7 +15819,7 @@
         },
         "wrap-ansi": {
           "version": "6.2.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
           "integrity": "sha1-6Tk7oHEC5skaOyIUePAlfNKFblM=",
           "dev": true,
           "requires": {
@@ -15830,7 +15830,7 @@
         },
         "yargs-parser": {
           "version": "18.1.3",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/yargs-parser/-/yargs-parser-18.1.3.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/yargs-parser/-/yargs-parser-18.1.3.tgz",
           "integrity": "sha1-vmjEl1xrKr9GkjawyHA2L6sJp7A=",
           "dev": true,
           "requires": {
@@ -15842,7 +15842,7 @@
     },
     "yargs-parser": {
       "version": "13.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/yargs-parser/-/yargs-parser-13.1.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/yargs-parser/-/yargs-parser-13.1.2.tgz",
       "integrity": "sha1-Ew8JcC667vJlDVTObj5XBvek+zg=",
       "dev": true,
       "requires": {
@@ -15852,7 +15852,7 @@
     },
     "yargs-unparser": {
       "version": "1.6.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/yargs-unparser/-/yargs-unparser-1.6.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/yargs-unparser/-/yargs-unparser-1.6.0.tgz",
       "integrity": "sha1-7yXCx2n/a9CeSw+dfGBfsnhG6p8=",
       "dev": true,
       "requires": {
@@ -15863,25 +15863,25 @@
       "dependencies": {
         "ansi-regex": {
           "version": "4.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-4.1.0.tgz",
           "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc=",
           "dev": true
         },
         "emoji-regex": {
           "version": "7.0.3",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/emoji-regex/-/emoji-regex-7.0.3.tgz",
           "integrity": "sha1-kzoEBShgyF6DwSJHnEdIqOTHIVY=",
           "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
         "string-width": {
           "version": "3.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string-width/-/string-width-3.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/string-width/-/string-width-3.1.0.tgz",
           "integrity": "sha1-InZ74htirxCBV0MG9prFG2IgOWE=",
           "dev": true,
           "requires": {
@@ -15892,7 +15892,7 @@
         },
         "strip-ansi": {
           "version": "5.2.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
           "dev": true,
           "requires": {
@@ -15901,7 +15901,7 @@
         },
         "yargs": {
           "version": "13.3.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/yargs/-/yargs-13.3.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/yargs/-/yargs-13.3.2.tgz",
           "integrity": "sha1-rX/+/sGqWVZayRX4Lcyzipwxot0=",
           "dev": true,
           "requires": {
@@ -15921,7 +15921,7 @@
     },
     "yauzl": {
       "version": "2.10.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/yauzl/-/yauzl-2.10.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/yauzl/-/yauzl-2.10.0.tgz",
       "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
       "dev": true,
       "requires": {
@@ -15931,13 +15931,13 @@
     },
     "yeast": {
       "version": "0.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/yeast/-/yeast-0.1.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/yeast/-/yeast-0.1.2.tgz",
       "integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk=",
       "dev": true
     },
     "zip-stream": {
       "version": "2.1.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/zip-stream/-/zip-stream-2.1.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/zip-stream/-/zip-stream-2.1.3.tgz",
       "integrity": "sha1-JsxL25NkGoWQ3QcRLh93rxdYhls=",
       "dev": true,
       "requires": {
@@ -15948,7 +15948,7 @@
       "dependencies": {
         "readable-stream": {
           "version": "3.6.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/readable-stream/-/readable-stream-3.6.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/readable-stream/-/readable-stream-3.6.0.tgz",
           "integrity": "sha1-M3u9o63AcGvT4CRCaihtS0sskZg=",
           "dev": true,
           "requires": {
@@ -15959,13 +15959,13 @@
         },
         "safe-buffer": {
           "version": "5.2.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/safe-buffer/-/safe-buffer-5.2.1.tgz",
           "integrity": "sha1-Hq+fqb2x/dTsdfWPnNtOa3gn7sY=",
           "dev": true
         },
         "string_decoder": {
           "version": "1.3.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string_decoder/-/string_decoder-1.3.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/string_decoder/-/string_decoder-1.3.0.tgz",
           "integrity": "sha1-QvEUWUpGzxqOMLCoT1bHjD7awh4=",
           "dev": true,
           "requires": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,28 +5,28 @@
   "requires": true,
   "dependencies": {
     "@babel/code-frame": {
-      "version": "7.10.1",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/code-frame/-/code-frame-7.10.1.tgz",
-      "integrity": "sha1-1UgcUJXaocV+FuVMb5GYRDr7Sf8=",
+      "version": "7.10.3",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/code-frame/-/code-frame-7.10.3.tgz",
+      "integrity": "sha1-MkvP2NNc09R9rhjN5j11IIZDXpo=",
       "dev": true,
       "requires": {
-        "@babel/highlight": "^7.10.1"
+        "@babel/highlight": "^7.10.3"
       }
     },
     "@babel/core": {
-      "version": "7.10.2",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/core/-/core-7.10.2.tgz",
-      "integrity": "sha1-vWeGBGZoqSWsK9L9lbV5uSojs2o=",
+      "version": "7.10.3",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/core/-/core-7.10.3.tgz",
+      "integrity": "sha1-c7Do3e7B4/3Xot5YemDhfEQOx34=",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.10.1",
-        "@babel/generator": "^7.10.2",
+        "@babel/code-frame": "^7.10.3",
+        "@babel/generator": "^7.10.3",
         "@babel/helper-module-transforms": "^7.10.1",
         "@babel/helpers": "^7.10.1",
-        "@babel/parser": "^7.10.2",
-        "@babel/template": "^7.10.1",
-        "@babel/traverse": "^7.10.1",
-        "@babel/types": "^7.10.2",
+        "@babel/parser": "^7.10.3",
+        "@babel/template": "^7.10.3",
+        "@babel/traverse": "^7.10.3",
+        "@babel/types": "^7.10.3",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.1",
@@ -67,12 +67,12 @@
       }
     },
     "@babel/generator": {
-      "version": "7.10.2",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/generator/-/generator-7.10.2.tgz",
-      "integrity": "sha1-D6W1sjiduL/fzDSStVHuIPXdaak=",
+      "version": "7.10.3",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/generator/-/generator-7.10.3.tgz",
+      "integrity": "sha1-Mrmg2WOnHXpU9fbBVlnD28KlI6U=",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.10.2",
+        "@babel/types": "^7.10.3",
         "jsesc": "^2.5.1",
         "lodash": "^4.17.13",
         "source-map": "^0.5.0"
@@ -96,13 +96,13 @@
       }
     },
     "@babel/helper-builder-binary-assignment-operator-visitor": {
-      "version": "7.10.1",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.10.1.tgz",
-      "integrity": "sha1-DsfZvoF0k0UyZh+HeD6xjXIpAFk=",
+      "version": "7.10.3",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.10.3.tgz",
+      "integrity": "sha1-TpAS1nAb7wAwNI1/nICCCb0+hoc=",
       "dev": true,
       "requires": {
-        "@babel/helper-explode-assignable-expression": "^7.10.1",
-        "@babel/types": "^7.10.1"
+        "@babel/helper-explode-assignable-expression": "^7.10.3",
+        "@babel/types": "^7.10.3"
       }
     },
     "@babel/helper-create-regexp-features-plugin": {
@@ -117,62 +117,62 @@
       }
     },
     "@babel/helper-define-map": {
-      "version": "7.10.1",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/helper-define-map/-/helper-define-map-7.10.1.tgz",
-      "integrity": "sha1-XmnugwhkhHDdeQDRWcBEwQKFIh0=",
+      "version": "7.10.3",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/helper-define-map/-/helper-define-map-7.10.3.tgz",
+      "integrity": "sha1-0nEgpeV8hHJ7MJRFSbLf7KYkAag=",
       "dev": true,
       "requires": {
-        "@babel/helper-function-name": "^7.10.1",
-        "@babel/types": "^7.10.1",
+        "@babel/helper-function-name": "^7.10.3",
+        "@babel/types": "^7.10.3",
         "lodash": "^4.17.13"
       }
     },
     "@babel/helper-explode-assignable-expression": {
-      "version": "7.10.1",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.10.1.tgz",
-      "integrity": "sha1-6ddjBe4RYspGc1euJd+U8XmvK34=",
+      "version": "7.10.3",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.10.3.tgz",
+      "integrity": "sha1-ncFPDPooM+qDCpyKHHQrbnRhsF4=",
       "dev": true,
       "requires": {
-        "@babel/traverse": "^7.10.1",
-        "@babel/types": "^7.10.1"
+        "@babel/traverse": "^7.10.3",
+        "@babel/types": "^7.10.3"
       }
     },
     "@babel/helper-function-name": {
-      "version": "7.10.1",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/helper-function-name/-/helper-function-name-7.10.1.tgz",
-      "integrity": "sha1-kr1jgpv8khWsqdne+oX1a1OUVPQ=",
+      "version": "7.10.3",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/helper-function-name/-/helper-function-name-7.10.3.tgz",
+      "integrity": "sha1-eTFs11qfolupeH/1RUQwftRE8Zc=",
       "dev": true,
       "requires": {
-        "@babel/helper-get-function-arity": "^7.10.1",
-        "@babel/template": "^7.10.1",
-        "@babel/types": "^7.10.1"
+        "@babel/helper-get-function-arity": "^7.10.3",
+        "@babel/template": "^7.10.3",
+        "@babel/types": "^7.10.3"
       }
     },
     "@babel/helper-get-function-arity": {
-      "version": "7.10.1",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.1.tgz",
-      "integrity": "sha1-cwM5CoG6fLWWE4laGSuThQ43P30=",
+      "version": "7.10.3",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.3.tgz",
+      "integrity": "sha1-Oij3sozMdxnqzZIjtln98WLkxF4=",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.10.1"
+        "@babel/types": "^7.10.3"
       }
     },
     "@babel/helper-member-expression-to-functions": {
-      "version": "7.10.1",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.10.1.tgz",
-      "integrity": "sha1-Qyln/X4SpK/vZsRofUyiK8BFbxU=",
+      "version": "7.10.3",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.10.3.tgz",
+      "integrity": "sha1-vDZjrIGsV8ORSP70xpv0ine6jdY=",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.10.1"
+        "@babel/types": "^7.10.3"
       }
     },
     "@babel/helper-module-imports": {
-      "version": "7.10.1",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/helper-module-imports/-/helper-module-imports-7.10.1.tgz",
-      "integrity": "sha1-3TMb1FvMxWbOdwBOnQX+F63ROHY=",
+      "version": "7.10.3",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/helper-module-imports/-/helper-module-imports-7.10.3.tgz",
+      "integrity": "sha1-dm+h1XYI5T5WdvI65JjsepXhsRo=",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.10.1"
+        "@babel/types": "^7.10.3"
       }
     },
     "@babel/helper-module-transforms": {
@@ -191,18 +191,18 @@
       }
     },
     "@babel/helper-optimise-call-expression": {
-      "version": "7.10.1",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.1.tgz",
-      "integrity": "sha1-tKHyVhhwzhJHzt2wKjhg+pbXJUM=",
+      "version": "7.10.3",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.3.tgz",
+      "integrity": "sha1-9TxLZ4MJMZWw9pMwQ5kIhBZgxTA=",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.10.1"
+        "@babel/types": "^7.10.3"
       }
     },
     "@babel/helper-plugin-utils": {
-      "version": "7.10.1",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.1.tgz",
-      "integrity": "sha1-7Fpc8O7JJbZsYFgDKLEiwBIwoSc=",
+      "version": "7.10.3",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.3.tgz",
+      "integrity": "sha1-qsRczPi8GHO5moXzS87vO+tdMkQ=",
       "dev": true
     },
     "@babel/helper-regex": {
@@ -215,16 +215,16 @@
       }
     },
     "@babel/helper-remap-async-to-generator": {
-      "version": "7.10.1",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.10.1.tgz",
-      "integrity": "sha1-utaqpP85zo1Lgsyq4L/g99u19DI=",
+      "version": "7.10.3",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.10.3.tgz",
+      "integrity": "sha1-GFZPimdIvkZpcBlbh26LujvM9EI=",
       "dev": true,
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.10.1",
         "@babel/helper-wrap-function": "^7.10.1",
-        "@babel/template": "^7.10.1",
-        "@babel/traverse": "^7.10.1",
-        "@babel/types": "^7.10.1"
+        "@babel/template": "^7.10.3",
+        "@babel/traverse": "^7.10.3",
+        "@babel/types": "^7.10.3"
       }
     },
     "@babel/helper-replace-supers": {
@@ -259,9 +259,9 @@
       }
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.10.1",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.1.tgz",
-      "integrity": "sha1-V3CwwagmxPU/Xt5eFTFj4DGOlLU=",
+      "version": "7.10.3",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.3.tgz",
+      "integrity": "sha1-YNmEf5jEzqGyeeAF/bfCi+VBLRU=",
       "dev": true
     },
     "@babel/helper-wrap-function": {
@@ -288,12 +288,12 @@
       }
     },
     "@babel/highlight": {
-      "version": "7.10.1",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/highlight/-/highlight-7.10.1.tgz",
-      "integrity": "sha1-hB0Ji6YTuhpCeis4PXnjVVLDiuA=",
+      "version": "7.10.3",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/highlight/-/highlight-7.10.3.tgz",
+      "integrity": "sha1-xjO7NK3wfFwTFWaS9ZIsgexT8o0=",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.10.1",
+        "@babel/helper-validator-identifier": "^7.10.3",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       },
@@ -312,9 +312,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.10.2",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/parser/-/parser-7.10.2.tgz",
-      "integrity": "sha1-hxgH8QRCuS/5fkeDubVPagyoEtA=",
+      "version": "7.10.3",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/parser/-/parser-7.10.3.tgz",
+      "integrity": "sha1-fnHYkrDW59BKGvTDx51ywfEPUxU=",
       "dev": true
     },
     "@babel/plugin-external-helpers": {
@@ -327,23 +327,23 @@
       }
     },
     "@babel/plugin-proposal-async-generator-functions": {
-      "version": "7.10.1",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.10.1.tgz",
-      "integrity": "sha1-aRGvW6LmFcT/PEl/4vR7Nb9tflU=",
+      "version": "7.10.3",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.10.3.tgz",
+      "integrity": "sha1-WgJFPUblNi4gc8cni+qy5TrX2Tk=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.10.1",
-        "@babel/helper-remap-async-to-generator": "^7.10.1",
+        "@babel/helper-plugin-utils": "^7.10.3",
+        "@babel/helper-remap-async-to-generator": "^7.10.3",
         "@babel/plugin-syntax-async-generators": "^7.8.0"
       }
     },
     "@babel/plugin-proposal-object-rest-spread": {
-      "version": "7.10.1",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.10.1.tgz",
-      "integrity": "sha1-y6RJCKyfFCZQtKZbiqBr80eNX7Y=",
+      "version": "7.10.3",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.10.3.tgz",
+      "integrity": "sha1-uNDSL3Cvo0rYS3ogD/dy+bn85HQ=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.10.1",
+        "@babel/helper-plugin-utils": "^7.10.3",
         "@babel/plugin-syntax-object-rest-spread": "^7.8.0",
         "@babel/plugin-transform-parameters": "^7.10.1"
       }
@@ -424,16 +424,16 @@
       }
     },
     "@babel/plugin-transform-classes": {
-      "version": "7.10.1",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/plugin-transform-classes/-/plugin-transform-classes-7.10.1.tgz",
-      "integrity": "sha1-bhHdbE365w9UBICkcCR37XZtcz8=",
+      "version": "7.10.3",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/plugin-transform-classes/-/plugin-transform-classes-7.10.3.tgz",
+      "integrity": "sha1-jZpla8PQHz/2nh/Ms1Sw+dcqxUQ=",
       "dev": true,
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.10.1",
-        "@babel/helper-define-map": "^7.10.1",
-        "@babel/helper-function-name": "^7.10.1",
-        "@babel/helper-optimise-call-expression": "^7.10.1",
-        "@babel/helper-plugin-utils": "^7.10.1",
+        "@babel/helper-define-map": "^7.10.3",
+        "@babel/helper-function-name": "^7.10.3",
+        "@babel/helper-optimise-call-expression": "^7.10.3",
+        "@babel/helper-plugin-utils": "^7.10.3",
         "@babel/helper-replace-supers": "^7.10.1",
         "@babel/helper-split-export-declaration": "^7.10.1",
         "globals": "^11.1.0"
@@ -448,12 +448,12 @@
       }
     },
     "@babel/plugin-transform-computed-properties": {
-      "version": "7.10.1",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.10.1.tgz",
-      "integrity": "sha1-Wao5kGRCnWTc5c9275uQtyRevQc=",
+      "version": "7.10.3",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.10.3.tgz",
+      "integrity": "sha1-06pu72fLlnFQ92+v8g8Ku/VTdXs=",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.10.1"
+        "@babel/helper-plugin-utils": "^7.10.3"
       }
     },
     "@babel/plugin-transform-destructuring": {
@@ -553,9 +553,9 @@
       }
     },
     "@babel/plugin-transform-regenerator": {
-      "version": "7.10.1",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.10.1.tgz",
-      "integrity": "sha1-EOF1y+e9tjzJs5+bP4I8XHxcVJA=",
+      "version": "7.10.3",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.10.3.tgz",
+      "integrity": "sha1-bsaA8UClzu/SkcIhy3Ex9tfoy20=",
       "dev": true,
       "requires": {
         "regenerator-transform": "^0.14.2"
@@ -590,13 +590,13 @@
       }
     },
     "@babel/plugin-transform-template-literals": {
-      "version": "7.10.1",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.10.1.tgz",
-      "integrity": "sha1-kUx7f0dSxXDqAFU7QoTa2AcOhig=",
+      "version": "7.10.3",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.10.3.tgz",
+      "integrity": "sha1-adObPUSzHntIZBczIlZYlM6TmyU=",
       "dev": true,
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.10.1",
-        "@babel/helper-plugin-utils": "^7.10.1"
+        "@babel/helper-plugin-utils": "^7.10.3"
       }
     },
     "@babel/plugin-transform-typeof-symbol": {
@@ -619,9 +619,9 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.10.2",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/runtime/-/runtime-7.10.2.tgz",
-      "integrity": "sha1-0QPyHyYCSX04NIoy4AhjfVBtuDk=",
+      "version": "7.10.3",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/runtime/-/runtime-7.10.3.tgz",
+      "integrity": "sha1-Zw0AJlWnw2ZUDGf2/TNCzQlQA2Q=",
       "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.4"
@@ -636,28 +636,28 @@
       }
     },
     "@babel/template": {
-      "version": "7.10.1",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/template/-/template-7.10.1.tgz",
-      "integrity": "sha1-4WcVSpTLXxSyjcWPU1bSFi9TmBE=",
+      "version": "7.10.3",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/template/-/template-7.10.3.tgz",
+      "integrity": "sha1-TRO8jjC/lbDOnRddMDBvQqLJp7g=",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.10.1",
-        "@babel/parser": "^7.10.1",
-        "@babel/types": "^7.10.1"
+        "@babel/code-frame": "^7.10.3",
+        "@babel/parser": "^7.10.3",
+        "@babel/types": "^7.10.3"
       }
     },
     "@babel/traverse": {
-      "version": "7.10.1",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/traverse/-/traverse-7.10.1.tgz",
-      "integrity": "sha1-u87zAx5BUqbAtQFH9JWN9Uyg3Sc=",
+      "version": "7.10.3",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/traverse/-/traverse-7.10.3.tgz",
+      "integrity": "sha1-CwFzF5Sqe3eyFLzZZmHxgoEVXX4=",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.10.1",
-        "@babel/generator": "^7.10.1",
-        "@babel/helper-function-name": "^7.10.1",
+        "@babel/code-frame": "^7.10.3",
+        "@babel/generator": "^7.10.3",
+        "@babel/helper-function-name": "^7.10.3",
         "@babel/helper-split-export-declaration": "^7.10.1",
-        "@babel/parser": "^7.10.1",
-        "@babel/types": "^7.10.1",
+        "@babel/parser": "^7.10.3",
+        "@babel/types": "^7.10.3",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
         "lodash": "^4.17.13"
@@ -687,14 +687,25 @@
       }
     },
     "@babel/types": {
-      "version": "7.10.2",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/types/-/types-7.10.2.tgz",
-      "integrity": "sha1-MCg74xytDb9vsAvUBkHKDqZ1Fy0=",
+      "version": "7.10.3",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@babel/types/-/types-7.10.3.tgz",
+      "integrity": "sha1-ZTXjt5/qhqawngEuqFKPk1CZ3o4=",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.10.1",
+        "@babel/helper-validator-identifier": "^7.10.3",
         "lodash": "^4.17.13",
         "to-fast-properties": "^2.0.0"
+      }
+    },
+    "@dabh/diagnostics": {
+      "version": "2.0.2",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@dabh/diagnostics/-/diagnostics-2.0.2.tgz",
+      "integrity": "sha1-KQ0I97OBuPlGB9yPRxoSxnX52zE=",
+      "dev": true,
+      "requires": {
+        "colorspace": "1.1.x",
+        "enabled": "2.0.x",
+        "kuler": "^2.0.0"
       }
     },
     "@govflanders/vl-ui-core": {
@@ -933,9 +944,9 @@
       "dev": true
     },
     "@types/clean-css": {
-      "version": "4.2.1",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/clean-css/-/clean-css-4.2.1.tgz",
-      "integrity": "sha1-ywE0JB7F5u3htTRLyClmj9mHGo0=",
+      "version": "4.2.2",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/clean-css/-/clean-css-4.2.2.tgz",
+      "integrity": "sha1-mf159pOcKzJZOKHFaXEuB92X1wk=",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -1039,7 +1050,7 @@
     },
     "@types/glob": {
       "version": "7.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/glob/-/glob-7.1.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/glob/-/glob-7.1.2.tgz",
       "integrity": "sha1-BsomUhNTpUXZSgrcdPOKWdIyyYc=",
       "dev": true,
       "requires": {
@@ -1121,7 +1132,7 @@
     },
     "@types/node": {
       "version": "14.0.13",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/@types/node/-/node-14.0.13.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/@types/node/-/node-14.0.13.tgz",
       "integrity": "sha1-7hEo6IG4dMNxN0wfciAYk2FkF8k=",
       "dev": true
     },
@@ -1326,7 +1337,7 @@
     },
     "acorn": {
       "version": "7.3.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/acorn/-/acorn-7.3.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/acorn/-/acorn-7.3.1.tgz",
       "integrity": "sha1-hQEHVNtTw/uvO56j4IOqXF0Uf/0=",
       "dev": true
     },
@@ -1347,9 +1358,9 @@
       "dev": true
     },
     "acorn-walk": {
-      "version": "7.1.1",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/acorn-walk/-/acorn-walk-7.1.1.tgz",
-      "integrity": "sha1-NF8N/61cc15zc9L+yaECPmpEuD4=",
+      "version": "7.2.0",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/acorn-walk/-/acorn-walk-7.2.0.tgz",
+      "integrity": "sha1-DeiJpgEgOQmw++B7iTjcIdLpZ7w=",
       "dev": true
     },
     "adm-zip": {
@@ -1410,12 +1421,6 @@
           "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc=",
           "dev": true
         },
-        "emoji-regex": {
-          "version": "7.0.3",
-          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/emoji-regex/-/emoji-regex-7.0.3.tgz",
-          "integrity": "sha1-kzoEBShgyF6DwSJHnEdIqOTHIVY=",
-          "dev": true
-        },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
@@ -1445,9 +1450,9 @@
       }
     },
     "ansi-colors": {
-      "version": "3.2.3",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-colors/-/ansi-colors-3.2.3.tgz",
-      "integrity": "sha1-V9NbhoboUeLMBMQD8cACA5dqGBM=",
+      "version": "3.2.4",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-colors/-/ansi-colors-3.2.4.tgz",
+      "integrity": "sha1-46PaS/uubIapwoViXeEkojQCb78=",
       "dev": true
     },
     "ansi-escapes": {
@@ -2479,6 +2484,12 @@
           "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
           "dev": true
         },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc=",
+          "dev": true
+        },
         "has-flag": {
           "version": "4.0.0",
           "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/has-flag/-/has-flag-4.0.0.tgz",
@@ -2786,7 +2797,7 @@
     },
     "chalk": {
       "version": "4.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/chalk/-/chalk-4.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/chalk/-/chalk-4.1.0.tgz",
       "integrity": "sha1-ThSHCmGNni7dl92DRf2dncMVZGo=",
       "dev": true,
       "requires": {
@@ -2796,7 +2807,7 @@
       "dependencies": {
         "ansi-styles": {
           "version": "4.2.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-styles/-/ansi-styles-4.2.1.tgz",
           "integrity": "sha1-kK51xCTQCNJiTFvynq0xd+v881k=",
           "dev": true,
           "requires": {
@@ -2806,7 +2817,7 @@
         },
         "color-convert": {
           "version": "2.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/color-convert/-/color-convert-2.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/color-convert/-/color-convert-2.0.1.tgz",
           "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
           "dev": true,
           "requires": {
@@ -2815,19 +2826,19 @@
         },
         "color-name": {
           "version": "1.1.4",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/color-name/-/color-name-1.1.4.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
           "dev": true
         },
         "has-flag": {
           "version": "4.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/has-flag/-/has-flag-4.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
           "dev": true
         },
         "supports-color": {
           "version": "7.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/supports-color/-/supports-color-7.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/supports-color/-/supports-color-7.1.0.tgz",
           "integrity": "sha1-aOMlkd9z4lrRxLSRCKLsUHliv9E=",
           "dev": true,
           "requires": {
@@ -3022,12 +3033,6 @@
           "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc=",
           "dev": true
         },
-        "emoji-regex": {
-          "version": "7.0.3",
-          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/emoji-regex/-/emoji-regex-7.0.3.tgz",
-          "integrity": "sha1-kzoEBShgyF6DwSJHnEdIqOTHIVY=",
-          "dev": true
-        },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
@@ -3127,12 +3132,6 @@
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
       }
-    },
-    "colornames": {
-      "version": "1.1.1",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/colornames/-/colornames-1.1.1.tgz",
-      "integrity": "sha1-+IiQMGhcfE/54qVZ9Qd+t2qBb5Y=",
-      "dev": true
     },
     "colors": {
       "version": "1.4.0",
@@ -3854,17 +3853,6 @@
       "integrity": "sha1-AU7o+PZpxcWAI9pkuBecCDooxGw=",
       "dev": true
     },
-    "diagnostics": {
-      "version": "1.1.1",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/diagnostics/-/diagnostics-1.1.1.tgz",
-      "integrity": "sha1-yrasM99wydmnJ0kK5DrJladpsio=",
-      "dev": true,
-      "requires": {
-        "colorspace": "1.1.x",
-        "enabled": "1.0.x",
-        "kuler": "1.0.x"
-      }
-    },
     "dicer": {
       "version": "0.2.5",
       "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/dicer/-/dicer-0.2.5.tgz",
@@ -4093,19 +4081,16 @@
       "dev": true
     },
     "emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc=",
+      "version": "7.0.3",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/emoji-regex/-/emoji-regex-7.0.3.tgz",
+      "integrity": "sha1-kzoEBShgyF6DwSJHnEdIqOTHIVY=",
       "dev": true
     },
     "enabled": {
-      "version": "1.0.2",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/enabled/-/enabled-1.0.2.tgz",
-      "integrity": "sha1-ll9lE9LC0cX0ZStkouM5ZGf8L5M=",
-      "dev": true,
-      "requires": {
-        "env-variable": "0.0.x"
-      }
+      "version": "2.0.0",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/enabled/-/enabled-2.0.0.tgz",
+      "integrity": "sha1-+d2S7C1vS7wNXR5k4h1hzUZl58I=",
+      "dev": true
     },
     "encodeurl": {
       "version": "1.0.2",
@@ -4124,7 +4109,7 @@
     },
     "engine.io": {
       "version": "3.4.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/engine.io/-/engine.io-3.4.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/engine.io/-/engine.io-3.4.2.tgz",
       "integrity": "sha1-j8hO4AOI4+IoZF4KfT367tW9Eiw=",
       "dev": true,
       "requires": {
@@ -4138,13 +4123,13 @@
       "dependencies": {
         "cookie": {
           "version": "0.3.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cookie/-/cookie-0.3.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/cookie/-/cookie-0.3.1.tgz",
           "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
           "dev": true
         },
         "debug": {
           "version": "4.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-4.1.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/debug/-/debug-4.1.1.tgz",
           "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
           "dev": true,
           "requires": {
@@ -4153,7 +4138,7 @@
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.1.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ms/-/ms-2.1.2.tgz",
           "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
           "dev": true
         }
@@ -4161,7 +4146,7 @@
     },
     "engine.io-client": {
       "version": "3.4.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/engine.io-client/-/engine.io-client-3.4.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/engine.io-client/-/engine.io-client-3.4.3.tgz",
       "integrity": "sha1-GS0JhlQD4wl+NXXr/rOGHE0Bpmw=",
       "dev": true,
       "requires": {
@@ -4180,7 +4165,7 @@
       "dependencies": {
         "debug": {
           "version": "4.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-4.1.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/debug/-/debug-4.1.1.tgz",
           "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
           "dev": true,
           "requires": {
@@ -4189,13 +4174,13 @@
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.1.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ms/-/ms-2.1.2.tgz",
           "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
           "dev": true
         },
         "ws": {
           "version": "6.1.4",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ws/-/ws-6.1.4.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ws/-/ws-6.1.4.tgz",
           "integrity": "sha1-W1yIAK+rkl6UzLKdFTyNAsF3bvk=",
           "dev": true,
           "requires": {
@@ -4217,16 +4202,19 @@
         "has-binary2": "~1.0.2"
       }
     },
+    "enquirer": {
+      "version": "2.3.5",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/enquirer/-/enquirer-2.3.5.tgz",
+      "integrity": "sha1-OrK4ON8KnYq559/yNbDocS75I4E=",
+      "dev": true,
+      "requires": {
+        "ansi-colors": "^3.2.1"
+      }
+    },
     "entities": {
       "version": "2.0.3",
       "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/entities/-/entities-2.0.3.tgz",
       "integrity": "sha1-XEh+V0Krk8Fau12iJ1m4WQ7AO38=",
-      "dev": true
-    },
-    "env-variable": {
-      "version": "0.0.6",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/env-variable/-/env-variable-0.0.6.tgz",
-      "integrity": "sha1-dKsgs3hsVFtitKSBOrjPInJsmAg=",
       "dev": true
     },
     "error-ex": {
@@ -4239,22 +4227,22 @@
       }
     },
     "es-abstract": {
-      "version": "1.17.5",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/es-abstract/-/es-abstract-1.17.5.tgz",
-      "integrity": "sha1-2MnR1myJgfuSAOIlHXme7pJ3Suk=",
+      "version": "1.17.6",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/es-abstract/-/es-abstract-1.17.6.tgz",
+      "integrity": "sha1-kUIHFweFeyysx7iey2cDFsPi1So=",
       "dev": true,
       "requires": {
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
         "has-symbols": "^1.0.1",
-        "is-callable": "^1.1.5",
-        "is-regex": "^1.0.5",
+        "is-callable": "^1.2.0",
+        "is-regex": "^1.1.0",
         "object-inspect": "^1.7.0",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.0",
-        "string.prototype.trimleft": "^2.1.1",
-        "string.prototype.trimright": "^2.1.1"
+        "string.prototype.trimend": "^1.0.1",
+        "string.prototype.trimstart": "^1.0.1"
       }
     },
     "es-to-primitive": {
@@ -4302,9 +4290,9 @@
       "dev": true
     },
     "escodegen": {
-      "version": "1.14.2",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/escodegen/-/escodegen-1.14.2.tgz",
-      "integrity": "sha1-FKtxv1AmwqoIFzr7oixvMXMoSoQ=",
+      "version": "1.14.3",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/escodegen/-/escodegen-1.14.3.tgz",
+      "integrity": "sha1-TnuB+6YVgdyXWC7XjKt/Do1j9QM=",
       "dev": true,
       "requires": {
         "esprima": "^4.0.1",
@@ -4356,9 +4344,9 @@
       }
     },
     "eslint": {
-      "version": "7.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/eslint/-/eslint-7.2.0.tgz",
-      "integrity": "sha1-1BsuR4BLMNursJOpZ/soPVYAguY=",
+      "version": "7.3.1",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/eslint/-/eslint-7.3.1.tgz",
+      "integrity": "sha1-djkr1+REaNBGFJuhKNFWbFmsvhk=",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -4367,6 +4355,7 @@
         "cross-spawn": "^7.0.2",
         "debug": "^4.0.1",
         "doctrine": "^3.0.0",
+        "enquirer": "^2.3.5",
         "eslint-scope": "^5.1.0",
         "eslint-utils": "^2.0.0",
         "eslint-visitor-keys": "^1.2.0",
@@ -4380,7 +4369,6 @@
         "ignore": "^4.0.6",
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
-        "inquirer": "^7.0.0",
         "is-glob": "^4.0.0",
         "js-yaml": "^3.13.1",
         "json-stable-stringify-without-jsonify": "^1.0.1",
@@ -4401,13 +4389,13 @@
       "dependencies": {
         "ansi-regex": {
           "version": "5.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-5.0.0.tgz",
           "integrity": "sha1-OIU59VF5vzkznIGvMKZU1p+Hy3U=",
           "dev": true
         },
         "debug": {
           "version": "4.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-4.1.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/debug/-/debug-4.1.1.tgz",
           "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
           "dev": true,
           "requires": {
@@ -4416,25 +4404,25 @@
         },
         "ignore": {
           "version": "4.0.6",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ignore/-/ignore-4.0.6.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ignore/-/ignore-4.0.6.tgz",
           "integrity": "sha1-dQ49tYYgh7RzfrrIIH/9HvJ7Jfw=",
           "dev": true
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.1.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ms/-/ms-2.1.2.tgz",
           "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
           "dev": true
         },
         "semver": {
           "version": "7.3.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/semver/-/semver-7.3.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/semver/-/semver-7.3.2.tgz",
           "integrity": "sha1-YElisFK4HtB4aq6EOJ/7pw/9OTg=",
           "dev": true
         },
         "strip-ansi": {
           "version": "6.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-6.0.0.tgz",
           "integrity": "sha1-CxVx3XZpzNTz4G4U7x7tJiJa5TI=",
           "dev": true,
           "requires": {
@@ -4466,7 +4454,7 @@
     },
     "eslint-scope": {
       "version": "5.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/eslint-scope/-/eslint-scope-5.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/eslint-scope/-/eslint-scope-5.1.0.tgz",
       "integrity": "sha1-0Plx3+WcaeDK2mhLI9Sdv4JgDOU=",
       "dev": true,
       "requires": {
@@ -4475,23 +4463,23 @@
       }
     },
     "eslint-utils": {
-      "version": "2.0.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/eslint-utils/-/eslint-utils-2.0.0.tgz",
-      "integrity": "sha1-e+HMcPJ6cqds0UqmmLyr7WiQ4c0=",
+      "version": "2.1.0",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/eslint-utils/-/eslint-utils-2.1.0.tgz",
+      "integrity": "sha1-0t5eA0JOcH3BDHQGjd7a5wh0Gyc=",
       "dev": true,
       "requires": {
         "eslint-visitor-keys": "^1.1.0"
       }
     },
     "eslint-visitor-keys": {
-      "version": "1.2.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/eslint-visitor-keys/-/eslint-visitor-keys-1.2.0.tgz",
-      "integrity": "sha1-dEFayISHRJX3jsKpc0lSU0TJgfo=",
+      "version": "1.3.0",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+      "integrity": "sha1-MOvR73wv3/AcOk8VEESvJfqwUj4=",
       "dev": true
     },
     "espree": {
       "version": "7.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/espree/-/espree-7.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/espree/-/espree-7.1.0.tgz",
       "integrity": "sha1-qcfxinUgVnNb8boUyxtwrcOlzhw=",
       "dev": true,
       "requires": {
@@ -4907,7 +4895,7 @@
     },
     "extract-zip": {
       "version": "2.0.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/extract-zip/-/extract-zip-2.0.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/extract-zip/-/extract-zip-2.0.1.tgz",
       "integrity": "sha1-Zj3KVv5G34kNXxMe9KBtIruLoTo=",
       "dev": true,
       "requires": {
@@ -4919,7 +4907,7 @@
       "dependencies": {
         "debug": {
           "version": "4.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/debug/-/debug-4.1.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/debug/-/debug-4.1.1.tgz",
           "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
           "dev": true,
           "requires": {
@@ -4928,7 +4916,7 @@
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ms/-/ms-2.1.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ms/-/ms-2.1.2.tgz",
           "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
           "dev": true
         }
@@ -4942,14 +4930,14 @@
     },
     "fast-deep-equal": {
       "version": "3.1.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha1-On1WtVnWy8PrUSMlJE5hmmXGxSU=",
       "dev": true
     },
     "fast-glob": {
-      "version": "3.2.2",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/fast-glob/-/fast-glob-3.2.2.tgz",
-      "integrity": "sha1-reGp2RFIll1L98UfcuHKZi0y5j0=",
+      "version": "3.2.4",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/fast-glob/-/fast-glob-3.2.4.tgz",
+      "integrity": "sha1-0grvv5lXk4Pn88xmUpFYybmFVNM=",
       "dev": true,
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -5003,9 +4991,9 @@
       "dev": true
     },
     "fetch-mock": {
-      "version": "9.10.1",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/fetch-mock/-/fetch-mock-9.10.1.tgz",
-      "integrity": "sha1-Hwp6N5VJCVa/TP1fpv+RK8TccdM=",
+      "version": "9.10.2",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/fetch-mock/-/fetch-mock-9.10.2.tgz",
+      "integrity": "sha1-aPM9DFmM1e8eQb3crN5j657Fzx8=",
       "dev": true,
       "requires": {
         "babel-runtime": "^6.26.0",
@@ -5309,6 +5297,12 @@
       "version": "2.0.2",
       "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/flatted/-/flatted-2.0.2.tgz",
       "integrity": "sha1-RXWyHivO50NKqb5mL0t7X5wrUTg=",
+      "dev": true
+    },
+    "fn.name": {
+      "version": "1.1.0",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/fn.name/-/fn.name-1.1.0.tgz",
+      "integrity": "sha1-JsrYAXlnrqhzG8QpYdBKPVmIrMw=",
       "dev": true
     },
     "follow-redirects": {
@@ -6523,9 +6517,9 @@
       "dev": true
     },
     "inquirer": {
-      "version": "7.1.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/inquirer/-/inquirer-7.1.0.tgz",
-      "integrity": "sha1-EpigGFmIPhfHJkuChwrhA0+S3Sk=",
+      "version": "7.2.0",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/inquirer/-/inquirer-7.2.0.tgz",
+      "integrity": "sha1-Y86Z2CMJDefrQg5LsF5vNEmqOJo=",
       "dev": true,
       "requires": {
         "ansi-escapes": "^4.2.1",
@@ -6582,6 +6576,12 @@
           "version": "1.1.4",
           "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc=",
           "dev": true
         },
         "has-flag": {
@@ -6794,7 +6794,7 @@
     },
     "invert-kv": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/invert-kv/-/invert-kv-2.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/invert-kv/-/invert-kv-2.0.0.tgz",
       "integrity": "sha1-c5P1r6Weyf9fZ6J2INEcIm4+7AI=",
       "dev": true
     },
@@ -7437,9 +7437,9 @@
       }
     },
     "jszip": {
-      "version": "3.4.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/jszip/-/jszip-3.4.0.tgz",
-      "integrity": "sha1-GmlCH6Xwu5vCIqRryogYL7oHU1A=",
+      "version": "3.5.0",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/jszip/-/jszip-3.5.0.tgz",
+      "integrity": "sha1-tP0fNoJFNGZY54H+yWdYAkieFfY=",
       "dev": true,
       "requires": {
         "lie": "~3.3.0",
@@ -7470,13 +7470,10 @@
       "dev": true
     },
     "kuler": {
-      "version": "1.0.1",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/kuler/-/kuler-1.0.1.tgz",
-      "integrity": "sha1-73x4TzbJ+24W3TFQ0VJneysCKKY=",
-      "dev": true,
-      "requires": {
-        "colornames": "^1.1.1"
-      }
+      "version": "2.0.0",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/kuler/-/kuler-2.0.0.tgz",
+      "integrity": "sha1-4sVwo4ADiPtEQH6FFTHB1nCwYbM=",
+      "dev": true
     },
     "latest-version": {
       "version": "5.1.0",
@@ -7537,7 +7534,7 @@
     },
     "lcid": {
       "version": "2.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/lcid/-/lcid-2.0.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/lcid/-/lcid-2.0.0.tgz",
       "integrity": "sha1-bvXS32DlL4LrIopMNz6NHzlyU88=",
       "dev": true,
       "requires": {
@@ -8521,6 +8518,12 @@
         "yargs-unparser": "1.6.0"
       },
       "dependencies": {
+        "ansi-colors": {
+          "version": "3.2.3",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-colors/-/ansi-colors-3.2.3.tgz",
+          "integrity": "sha1-V9NbhoboUeLMBMQD8cACA5dqGBM=",
+          "dev": true
+        },
         "ansi-regex": {
           "version": "4.1.0",
           "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-4.1.0.tgz",
@@ -8535,12 +8538,6 @@
           "requires": {
             "ms": "^2.1.1"
           }
-        },
-        "emoji-regex": {
-          "version": "7.0.3",
-          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/emoji-regex/-/emoji-regex-7.0.3.tgz",
-          "integrity": "sha1-kzoEBShgyF6DwSJHnEdIqOTHIVY=",
-          "dev": true
         },
         "glob": {
           "version": "7.1.3",
@@ -8936,7 +8933,7 @@
     },
     "np": {
       "version": "6.2.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/np/-/np-6.2.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/np/-/np-6.2.4.tgz",
       "integrity": "sha1-HKsRiLl2Sud5TsdApogcUpEDN9k=",
       "dev": true,
       "requires": {
@@ -8979,7 +8976,7 @@
       "dependencies": {
         "ansi-styles": {
           "version": "4.2.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-styles/-/ansi-styles-4.2.1.tgz",
           "integrity": "sha1-kK51xCTQCNJiTFvynq0xd+v881k=",
           "dev": true,
           "requires": {
@@ -8989,7 +8986,7 @@
         },
         "array-union": {
           "version": "1.0.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/array-union/-/array-union-1.0.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/array-union/-/array-union-1.0.2.tgz",
           "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
           "dev": true,
           "requires": {
@@ -8998,7 +8995,7 @@
         },
         "chalk": {
           "version": "3.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/chalk/-/chalk-3.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/chalk/-/chalk-3.0.0.tgz",
           "integrity": "sha1-P3PCv1JlkfV0zEksUeJFY0n4ROQ=",
           "dev": true,
           "requires": {
@@ -9008,7 +9005,7 @@
         },
         "color-convert": {
           "version": "2.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/color-convert/-/color-convert-2.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/color-convert/-/color-convert-2.0.1.tgz",
           "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
           "dev": true,
           "requires": {
@@ -9017,13 +9014,13 @@
         },
         "color-name": {
           "version": "1.1.4",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/color-name/-/color-name-1.1.4.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
           "dev": true
         },
         "del": {
           "version": "4.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/del/-/del-4.1.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/del/-/del-4.1.1.tgz",
           "integrity": "sha1-no8RciLqRKMf86FWwEm5kFKp8LQ=",
           "dev": true,
           "requires": {
@@ -9038,13 +9035,13 @@
         },
         "escape-string-regexp": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
           "integrity": "sha1-owME6Z2qMuI7L9IPUbq9B8/8o0Q=",
           "dev": true
         },
         "globby": {
           "version": "6.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/globby/-/globby-6.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/globby/-/globby-6.1.0.tgz",
           "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
           "dev": true,
           "requires": {
@@ -9057,7 +9054,7 @@
           "dependencies": {
             "pify": {
               "version": "2.3.0",
-              "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/pify/-/pify-2.3.0.tgz",
+              "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/pify/-/pify-2.3.0.tgz",
               "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
               "dev": true
             }
@@ -9065,25 +9062,25 @@
         },
         "has-flag": {
           "version": "4.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/has-flag/-/has-flag-4.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
           "dev": true
         },
         "p-map": {
           "version": "2.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/p-map/-/p-map-2.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/p-map/-/p-map-2.1.0.tgz",
           "integrity": "sha1-MQko/u+cnsxltosXaTAYpmXOoXU=",
           "dev": true
         },
         "semver": {
           "version": "7.3.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/semver/-/semver-7.3.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/semver/-/semver-7.3.2.tgz",
           "integrity": "sha1-YElisFK4HtB4aq6EOJ/7pw/9OTg=",
           "dev": true
         },
         "supports-color": {
           "version": "7.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/supports-color/-/supports-color-7.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/supports-color/-/supports-color-7.1.0.tgz",
           "integrity": "sha1-aOMlkd9z4lrRxLSRCKLsUHliv9E=",
           "dev": true,
           "requires": {
@@ -9241,9 +9238,9 @@
       }
     },
     "object-inspect": {
-      "version": "1.7.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/object-inspect/-/object-inspect-1.7.0.tgz",
-      "integrity": "sha1-9Pa9GBrXfwBrXs5gvQtvOY/3Smc=",
+      "version": "1.8.0",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/object-inspect/-/object-inspect-1.8.0.tgz",
+      "integrity": "sha1-34B+Xs9TpgnMa/6T6sPMe+WzqdA=",
       "dev": true
     },
     "object-keys": {
@@ -9333,10 +9330,13 @@
       }
     },
     "one-time": {
-      "version": "0.0.4",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/one-time/-/one-time-0.0.4.tgz",
-      "integrity": "sha1-+M33eISCb+Tf+T46nMN7HkSAdC4=",
-      "dev": true
+      "version": "1.0.0",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/one-time/-/one-time-1.0.0.tgz",
+      "integrity": "sha1-4GvBdK7SFO1Y7e3lc7Qzu/gny0U=",
+      "dev": true,
+      "requires": {
+        "fn.name": "1.x.x"
+      }
     },
     "onetime": {
       "version": "5.1.0",
@@ -9404,7 +9404,7 @@
     },
     "os-locale": {
       "version": "3.1.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/os-locale/-/os-locale-3.1.0.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/os-locale/-/os-locale-3.1.0.tgz",
       "integrity": "sha1-qAKm7hfyTBBIOrmTVxnO9O0Wvxo=",
       "dev": true,
       "requires": {
@@ -9415,7 +9415,7 @@
       "dependencies": {
         "cross-spawn": {
           "version": "6.0.5",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/cross-spawn/-/cross-spawn-6.0.5.tgz",
           "integrity": "sha1-Sl7Hxk364iw6FBJNus3uhG2Ay8Q=",
           "dev": true,
           "requires": {
@@ -9428,7 +9428,7 @@
         },
         "execa": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/execa/-/execa-1.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/execa/-/execa-1.0.0.tgz",
           "integrity": "sha1-xiNqW7TfbW8V6I5/AXeYIWdJ3dg=",
           "dev": true,
           "requires": {
@@ -9443,7 +9443,7 @@
         },
         "get-stream": {
           "version": "4.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/get-stream/-/get-stream-4.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/get-stream/-/get-stream-4.1.0.tgz",
           "integrity": "sha1-wbJVV189wh1Zv8ec09K0axw6VLU=",
           "dev": true,
           "requires": {
@@ -9452,7 +9452,7 @@
         },
         "npm-run-path": {
           "version": "2.0.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/npm-run-path/-/npm-run-path-2.0.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/npm-run-path/-/npm-run-path-2.0.2.tgz",
           "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
           "dev": true,
           "requires": {
@@ -9461,19 +9461,19 @@
         },
         "path-key": {
           "version": "2.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/path-key/-/path-key-2.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/path-key/-/path-key-2.0.1.tgz",
           "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
           "dev": true
         },
         "semver": {
           "version": "5.7.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/semver/-/semver-5.7.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/semver/-/semver-5.7.1.tgz",
           "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc=",
           "dev": true
         },
         "shebang-command": {
           "version": "1.2.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/shebang-command/-/shebang-command-1.2.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/shebang-command/-/shebang-command-1.2.0.tgz",
           "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
           "dev": true,
           "requires": {
@@ -9482,7 +9482,7 @@
         },
         "shebang-regex": {
           "version": "1.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/shebang-regex/-/shebang-regex-1.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/shebang-regex/-/shebang-regex-1.0.0.tgz",
           "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
           "dev": true
         }
@@ -10713,7 +10713,7 @@
     },
     "regenerate": {
       "version": "1.4.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/regenerate/-/regenerate-1.4.1.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/regenerate/-/regenerate-1.4.1.tgz",
       "integrity": "sha1-ytkq2Oa1kXc0hfvgWkhcr09Ffm8=",
       "dev": true
     },
@@ -10857,7 +10857,7 @@
     },
     "replace": {
       "version": "1.1.5",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/replace/-/replace-1.1.5.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/replace/-/replace-1.1.5.tgz",
       "integrity": "sha1-raxODNERtX2laDk8ugPz74+sf5Y=",
       "dev": true,
       "requires": {
@@ -10868,13 +10868,13 @@
       "dependencies": {
         "ansi-regex": {
           "version": "3.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
         "chalk": {
           "version": "2.4.2",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/chalk/-/chalk-2.4.2.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
           "dev": true,
           "requires": {
@@ -10885,7 +10885,7 @@
         },
         "cliui": {
           "version": "4.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/cliui/-/cliui-4.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/cliui/-/cliui-4.1.0.tgz",
           "integrity": "sha1-NIQi2+gtgAswIu709qwQvy5NG0k=",
           "dev": true,
           "requires": {
@@ -10896,25 +10896,25 @@
         },
         "get-caller-file": {
           "version": "1.0.3",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/get-caller-file/-/get-caller-file-1.0.3.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/get-caller-file/-/get-caller-file-1.0.3.tgz",
           "integrity": "sha1-+Xj6TJDR3+f/LWvtoqUV5xO9z0o=",
           "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
         "require-main-filename": {
           "version": "1.0.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/require-main-filename/-/require-main-filename-1.0.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/require-main-filename/-/require-main-filename-1.0.1.tgz",
           "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
           "dev": true
         },
         "string-width": {
           "version": "2.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string-width/-/string-width-2.1.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/string-width/-/string-width-2.1.1.tgz",
           "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
           "dev": true,
           "requires": {
@@ -10924,7 +10924,7 @@
         },
         "strip-ansi": {
           "version": "4.0.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
@@ -10933,7 +10933,7 @@
         },
         "wrap-ansi": {
           "version": "2.1.0",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
           "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
           "dev": true,
           "requires": {
@@ -10943,13 +10943,13 @@
           "dependencies": {
             "ansi-regex": {
               "version": "2.1.1",
-              "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-2.1.1.tgz",
+              "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-2.1.1.tgz",
               "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
               "dev": true
             },
             "is-fullwidth-code-point": {
               "version": "1.0.0",
-              "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+              "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
               "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
               "dev": true,
               "requires": {
@@ -10958,7 +10958,7 @@
             },
             "string-width": {
               "version": "1.0.2",
-              "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/string-width/-/string-width-1.0.2.tgz",
+              "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/string-width/-/string-width-1.0.2.tgz",
               "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "dev": true,
               "requires": {
@@ -10969,7 +10969,7 @@
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "dev": true,
               "requires": {
@@ -10980,7 +10980,7 @@
         },
         "yargs": {
           "version": "12.0.5",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/yargs/-/yargs-12.0.5.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/yargs/-/yargs-12.0.5.tgz",
           "integrity": "sha1-BfWZe2CWR7ZPZrgeO0sQo2jnrRM=",
           "dev": true,
           "requires": {
@@ -11000,7 +11000,7 @@
         },
         "yargs-parser": {
           "version": "11.1.1",
-          "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/yargs-parser/-/yargs-parser-11.1.1.tgz",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/yargs-parser/-/yargs-parser-11.1.1.tgz",
           "integrity": "sha1-h5oIZZc7yp9rq1y987HGfsfTvPQ=",
           "dev": true,
           "requires": {
@@ -11219,9 +11219,9 @@
       "dev": true
     },
     "sass": {
-      "version": "1.26.8",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/sass/-/sass-1.26.8.tgz",
-      "integrity": "sha1-MSZSUwch+VaNTEAAsNsH7G6yMyU=",
+      "version": "1.26.9",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/sass/-/sass-1.26.9.tgz",
+      "integrity": "sha1-c8EMu4jBKyKp4BB3Jb/WIpb0l48=",
       "dev": true,
       "requires": {
         "chokidar": ">=2.0.0 <4.0.0"
@@ -12386,28 +12386,6 @@
         "es-abstract": "^1.17.5"
       }
     },
-    "string.prototype.trimleft": {
-      "version": "2.1.2",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/string.prototype.trimleft/-/string.prototype.trimleft-2.1.2.tgz",
-      "integrity": "sha1-RAiqLl1t3QyagHObCH+8BnwDs8w=",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.5",
-        "string.prototype.trimstart": "^1.0.0"
-      }
-    },
-    "string.prototype.trimright": {
-      "version": "2.1.2",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/string.prototype.trimright/-/string.prototype.trimright-2.1.2.tgz",
-      "integrity": "sha1-x28c7zDyG7rYr+uNsVEUls+w8qM=",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.5",
-        "string.prototype.trimend": "^1.0.0"
-      }
-    },
     "string.prototype.trimstart": {
       "version": "1.0.1",
       "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz",
@@ -13190,12 +13168,6 @@
           "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc=",
           "dev": true
         },
-        "emoji-regex": {
-          "version": "7.0.3",
-          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/emoji-regex/-/emoji-regex-7.0.3.tgz",
-          "integrity": "sha1-kzoEBShgyF6DwSJHnEdIqOTHIVY=",
-          "dev": true
-        },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
@@ -13399,14 +13371,14 @@
       }
     },
     "terser": {
-      "version": "4.0.0",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/terser/-/terser-4.0.0.tgz",
-      "integrity": "sha1-7zVvbzWalj4sxnVRfyHBw4KHc3Q=",
+      "version": "4.8.0",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/terser/-/terser-4.8.0.tgz",
+      "integrity": "sha1-YwVjQ9fHC7KfOvZlhlpG/gOg3xc=",
       "dev": true,
       "requires": {
-        "commander": "^2.19.0",
+        "commander": "^2.20.0",
         "source-map": "~0.6.1",
-        "source-map-support": "~0.5.10"
+        "source-map-support": "~0.5.12"
       }
     },
     "text-encoding": {
@@ -13434,9 +13406,9 @@
       "dev": true
     },
     "thenify": {
-      "version": "3.3.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/thenify/-/thenify-3.3.0.tgz",
-      "integrity": "sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=",
+      "version": "3.3.1",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha1-iTLmhqQGYDigFt2eLKRq3Zg4qV8=",
       "dev": true,
       "requires": {
         "any-promise": "^1.0.0"
@@ -13758,13 +13730,10 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.9.4",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/uglify-js/-/uglify-js-3.9.4.tgz",
-      "integrity": "sha1-hnQCN34EPB/HsQIlOiK2TlhiQBs=",
-      "dev": true,
-      "requires": {
-        "commander": "~2.20.3"
-      }
+      "version": "3.10.0",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/uglify-js/-/uglify-js-3.10.0.tgz",
+      "integrity": "sha1-OXp+bjHOggv9HLVbgE7hQMWHqec=",
+      "dev": true
     },
     "underscore": {
       "version": "1.10.2",
@@ -14224,7 +14193,7 @@
     },
     "vl-ui-content-header": {
       "version": "3.0.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vl-ui-content-header/-/vl-ui-content-header-3.0.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vl-ui-content-header/-/vl-ui-content-header-3.0.3.tgz",
       "integrity": "sha1-ELMbxIJohRkKAzwZ9LD89qVOOsA=",
       "dev": true,
       "requires": {
@@ -14232,18 +14201,18 @@
       }
     },
     "vl-ui-core": {
-      "version": "5.5.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vl-ui-core/-/vl-ui-core-5.5.3.tgz",
-      "integrity": "sha1-0+EywD0doeHtOj6TXGdh5ugVTus=",
+      "version": "5.5.4",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vl-ui-core/-/vl-ui-core-5.5.4.tgz",
+      "integrity": "sha1-BeayutVDScM944WM26oURPUxg8A=",
       "dev": true,
       "requires": {
         "document-register-element": "1.14.3"
       }
     },
     "vl-ui-demo": {
-      "version": "1.1.1",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vl-ui-demo/-/vl-ui-demo-1.1.1.tgz",
-      "integrity": "sha1-aReXbZJFnbASZ4r1NM3QUKF935I=",
+      "version": "1.1.2",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vl-ui-demo/-/vl-ui-demo-1.1.2.tgz",
+      "integrity": "sha1-9Em7Umyb1R/bGqV8LgkqWlAd6Pg=",
       "dev": true,
       "requires": {
         "prismjs": "1.20.0",
@@ -14258,7 +14227,7 @@
     },
     "vl-ui-footer": {
       "version": "3.1.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vl-ui-footer/-/vl-ui-footer-3.1.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vl-ui-footer/-/vl-ui-footer-3.1.3.tgz",
       "integrity": "sha1-NAchRIjgl1SNEo6XvsJsq+7ygSQ=",
       "dev": true,
       "requires": {
@@ -14267,7 +14236,7 @@
     },
     "vl-ui-grid": {
       "version": "3.1.2",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vl-ui-grid/-/vl-ui-grid-3.1.2.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vl-ui-grid/-/vl-ui-grid-3.1.2.tgz",
       "integrity": "sha1-FU4tGRBRoLIhwrlAICkbs5cWK90=",
       "dev": true,
       "requires": {
@@ -14276,7 +14245,7 @@
     },
     "vl-ui-header": {
       "version": "3.1.3",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vl-ui-header/-/vl-ui-header-3.1.3.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vl-ui-header/-/vl-ui-header-3.1.3.tgz",
       "integrity": "sha1-1C4GfM/tcwoKpPT3R50VB+wNKu4=",
       "dev": true,
       "requires": {
@@ -14285,7 +14254,7 @@
     },
     "vl-ui-template": {
       "version": "3.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vl-ui-template/-/vl-ui-template-3.0.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vl-ui-template/-/vl-ui-template-3.0.4.tgz",
       "integrity": "sha1-BYZXg0f+CzGJzwgXjQPeGUBrjlM=",
       "dev": true,
       "requires": {
@@ -14294,7 +14263,7 @@
     },
     "vl-ui-titles": {
       "version": "3.0.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vl-ui-titles/-/vl-ui-titles-3.0.4.tgz",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vl-ui-titles/-/vl-ui-titles-3.0.4.tgz",
       "integrity": "sha1-c/4PARHmuBGTRSb70K9JZ8Qehps=",
       "dev": true,
       "requires": {
@@ -14302,9 +14271,9 @@
       }
     },
     "vl-ui-util": {
-      "version": "5.2.4",
-      "resolved": "http://artifactory-pr.lb.cumuli.be:8081/artifactory/api/npm/acd-npm/vl-ui-util/-/vl-ui-util-5.2.4.tgz",
-      "integrity": "sha1-vAautCG/xiZqRCOVrIr8+J53zjg=",
+      "version": "5.2.7",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/vl-ui-util/-/vl-ui-util-5.2.7.tgz",
+      "integrity": "sha1-SWv0jqKz5vJ6GHoQFlcGOMfqxsI=",
       "dev": true,
       "requires": {
         "chai": "^4.2.0",
@@ -14327,7 +14296,7 @@
         "sass": "^1.26.7",
         "selenium-webdriver": "^4.0.0-alpha.7",
         "sinon": "^9.0.2",
-        "terser": "4.0.0",
+        "terser": "4.8.0",
         "vl-ui-demo": "^1.1.1",
         "wct-browser-legacy": "^1.0.2",
         "web-component-tester": "^6.9.2",
@@ -15419,6 +15388,12 @@
           "integrity": "sha1-OIU59VF5vzkznIGvMKZU1p+Hy3U=",
           "dev": true
         },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc=",
+          "dev": true
+        },
         "is-fullwidth-code-point": {
           "version": "3.0.0",
           "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -15448,31 +15423,49 @@
       }
     },
     "winston": {
-      "version": "3.2.1",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/winston/-/winston-3.2.1.tgz",
-      "integrity": "sha1-YwYTd5dsc1hAKL4kkKGEYFX3fwc=",
+      "version": "3.3.2",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/winston/-/winston-3.3.2.tgz",
+      "integrity": "sha1-lDdz6o4cI1PgiKzWSpUseAmsB24=",
       "dev": true,
       "requires": {
-        "async": "^2.6.1",
-        "diagnostics": "^1.1.1",
-        "is-stream": "^1.1.0",
-        "logform": "^2.1.1",
-        "one-time": "0.0.4",
-        "readable-stream": "^3.1.1",
+        "@dabh/diagnostics": "^2.0.2",
+        "async": "^3.1.0",
+        "is-stream": "^2.0.0",
+        "logform": "^2.2.0",
+        "one-time": "^1.0.0",
+        "readable-stream": "^3.4.0",
         "stack-trace": "0.0.x",
         "triple-beam": "^1.3.0",
-        "winston-transport": "^4.3.0"
+        "winston-transport": "^4.4.0"
       },
       "dependencies": {
+        "async": {
+          "version": "3.2.0",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/async/-/async-3.2.0.tgz",
+          "integrity": "sha1-s6JoXF67ZB094C0WEALGD8n4VyA=",
+          "dev": true
+        },
+        "fecha": {
+          "version": "4.2.0",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/fecha/-/fecha-4.2.0.tgz",
+          "integrity": "sha1-P/tjlUU+Pz7/+FBATwpZtnR/X0E=",
+          "dev": true
+        },
+        "is-stream": {
+          "version": "2.0.0",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/is-stream/-/is-stream-2.0.0.tgz",
+          "integrity": "sha1-venDJoDW+uBBKdasnZIc54FfeOM=",
+          "dev": true
+        },
         "logform": {
-          "version": "2.1.2",
-          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/logform/-/logform-2.1.2.tgz",
-          "integrity": "sha1-lXFV6+tnoTFkBpglzmfdtbst02A=",
+          "version": "2.2.0",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/logform/-/logform-2.2.0.tgz",
+          "integrity": "sha1-QPA20ZFh/Ha2irUP3H/klVREkvI=",
           "dev": true,
           "requires": {
             "colors": "^1.2.1",
             "fast-safe-stringify": "^2.0.4",
-            "fecha": "^2.3.3",
+            "fecha": "^4.2.0",
             "ms": "^2.1.1",
             "triple-beam": "^1.3.0"
           }
@@ -15512,12 +15505,12 @@
       }
     },
     "winston-transport": {
-      "version": "4.3.0",
-      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/winston-transport/-/winston-transport-4.3.0.tgz",
-      "integrity": "sha1-32jAwgJILESNm0cxPAcwTC18LGY=",
+      "version": "4.4.0",
+      "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/winston-transport/-/winston-transport-4.4.0.tgz",
+      "integrity": "sha1-F69RjappDVsuzMqnrPeyDKeSXlk=",
       "dev": true,
       "requires": {
-        "readable-stream": "^2.3.6",
+        "readable-stream": "^2.3.7",
         "triple-beam": "^1.2.0"
       }
     },
@@ -15566,12 +15559,6 @@
           "version": "4.1.0",
           "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-4.1.0.tgz",
           "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc=",
-          "dev": true
-        },
-        "emoji-regex": {
-          "version": "7.0.3",
-          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/emoji-regex/-/emoji-regex-7.0.3.tgz",
-          "integrity": "sha1-kzoEBShgyF6DwSJHnEdIqOTHIVY=",
           "dev": true
         },
         "is-fullwidth-code-point": {
@@ -15757,6 +15744,12 @@
           "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
           "dev": true
         },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc=",
+          "dev": true
+        },
         "find-up": {
           "version": "4.1.0",
           "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/find-up/-/find-up-4.1.0.tgz",
@@ -15865,12 +15858,6 @@
           "version": "4.1.0",
           "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/ansi-regex/-/ansi-regex-4.1.0.tgz",
           "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc=",
-          "dev": true
-        },
-        "emoji-regex": {
-          "version": "7.0.3",
-          "resolved": "https://repository.milieuinfo.be:443/artifactory/api/npm/acd-npm/emoji-regex/-/emoji-regex-7.0.3.tgz",
-          "integrity": "sha1-kzoEBShgyF6DwSJHnEdIqOTHIVY=",
           "dev": true
         },
         "is-fullwidth-code-point": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   },
   "devDependencies": {
     "@govflanders/vl-ui-core": "^3.9.2",
-    "vl-ui-util": "^5.2.4"
+    "vl-ui-util": "^5.2.4",
+    "yargs": "^15.3.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
   },
   "devDependencies": {
     "@govflanders/vl-ui-core": "^3.9.2",
-    "vl-ui-util": "^5.2.4",
-    "yargs": "^15.3.1"
+    "vl-ui-util": "^5.2.4"
   }
 }

--- a/test/e2e/config.js
+++ b/test/e2e/config.js
@@ -1,7 +1,9 @@
 const yargs = require('yargs').argv;
 
+console.log('========================' + process.argv);
+
 function browserName() {
-  if (process.argv) {
+  if (process.argv || yargs) {
     if (process.argv.includes('chrome') || yargs.chrome) {
       return 'chrome';
     } else if (process.argv.includes('firefox') || yargs.firefox) {

--- a/test/e2e/config.js
+++ b/test/e2e/config.js
@@ -1,27 +1,22 @@
-const argv = require('yargs').argv;
-
 function browserName() {
-  if (argv) {
-    if (argv.chrome) {
+  if (process.argv) {
+    if (process.argv.includes('chrome')) {
       return 'chrome';
-    } else if (argv.firefox) {
+    } else if (process.argv.includes('firefox')) {
       return 'firefox';
-    } else if (argv.opera) {
+    } else if (process.argv.includes('opera')) {
       return 'opera';
-    } else if (argv.safari) {
+    } else if (process.argv.includes('safari')) {
       return 'safari';
     } else {
       console.warn('Geen geldige browser gevonden, default Chrome browser!');
       return 'chrome';
     }
-  } else {
-    console.error('Geen argumenten meegegeven!');
-    process.exit(1);
   }
 }
 
 function gridEnabled() {
-  return !!argv.grid;
+  return process.argv.includes('grid');
 }
 
 module.exports = {

--- a/test/e2e/config.js
+++ b/test/e2e/config.js
@@ -1,12 +1,14 @@
+const yargs = require('yargs').argv;
+
 function browserName() {
   if (process.argv) {
-    if (process.argv.includes('chrome')) {
+    if (process.argv.includes('chrome') || yargs.chrome) {
       return 'chrome';
-    } else if (process.argv.includes('firefox')) {
+    } else if (process.argv.includes('firefox') || yargs.firefox) {
       return 'firefox';
-    } else if (process.argv.includes('opera')) {
+    } else if (process.argv.includes('opera') || yargs.opera) {
       return 'opera';
-    } else if (process.argv.includes('safari')) {
+    } else if (process.argv.includes('safari') || yargs.safari) {
       return 'safari';
     } else {
       console.warn('Geen geldige browser gevonden, default Chrome browser!');
@@ -16,7 +18,7 @@ function browserName() {
 }
 
 function gridEnabled() {
-  return process.argv.includes('grid');
+  return process.argv.includes('grid') || yargs.grid;
 }
 
 module.exports = {

--- a/test/e2e/config.js
+++ b/test/e2e/config.js
@@ -1,7 +1,5 @@
 const yargs = require('yargs').argv;
 
-console.log('========================' + process.argv);
-
 function browserName() {
   if (process.argv || yargs) {
     if (process.argv.includes('chrome') || yargs.chrome) {


### PR DESCRIPTION
Er wordt gebruik gemaakt van de standaard parsing van CLI parameters in NPM. Op deze manier kan de gebruiker bijvoorbeeld `--chrome` meegeven via de CLI en wordt deze parameter doorgegeven aan het NPM run script. Via yargs is het niet mogelijk om parameters aan NPM run scripts door te geven. Daarom is er gekozen voor de combinatie van native NPM run parameters met yargs.

In de toekomst kunnen we eventueel voorzien dat er meerdere parameters tegelijk kunnen verwerkt worden zodat het NPM run script `npm run test:component:server:start && mocha --chrome && mocha --firefox` kan afgekort worden naar `npm run test:component:server:start && mocha --chrome --firefox`. 